### PR TITLE
Reference-data now returns geolocations

### DIFF
--- a/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/AddLocationToReferenceDataIT.java
+++ b/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/AddLocationToReferenceDataIT.java
@@ -1,0 +1,59 @@
+package no.dcat.harvester.crawler;
+
+import no.dcat.datastore.domain.dcat.client.BasicAuthRestTemplate;
+import no.dcat.datastore.domain.dcat.client.LoadLocations;
+import no.dcat.shared.SkosCode;
+import no.dcat.shared.testcategories.IntegrationTest;
+import org.apache.http.util.Args;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+@ActiveProfiles(value = "unit-integration")
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Category(IntegrationTest.class)
+public class AddLocationToReferenceDataIT {
+
+    @Value("${application.themesHostname}")
+    private String themesHostName;
+
+    @Value("${application.httpUsername}")
+    private String httpUsername;
+
+    @Value("${application.httpPassword}")
+    private String httpPassword;
+
+    private LoadLocations loadLocations;
+    private BasicAuthRestTemplate template;
+
+    @Before
+    public void setup() {
+        loadLocations = new LoadLocations(themesHostName, httpUsername, httpPassword);
+        template = new BasicAuthRestTemplate(httpUsername, httpPassword);
+    }
+
+    @Test
+    public void loadALocationOK() {
+
+        String aalesundKommuneUri = "http://data.geonorge.no/administrativeEnheter/kommune/id/172758";
+
+        loadLocations.postLocationToReferenceData(template, aalesundKommuneUri);
+
+        SkosCode location = loadLocations.getLocation(aalesundKommuneUri);
+
+        assertThat(location, is(notNullValue()));
+        assertThat(location.getPrefLabel().get("no"), is("Ålesund"));
+    }
+
+}

--- a/applications/reference-data/src/main/java/no/dcat/themes/service/CodesService.java
+++ b/applications/reference-data/src/main/java/no/dcat/themes/service/CodesService.java
@@ -2,6 +2,9 @@ package no.dcat.themes.service;
 
 import com.google.gson.Gson;
 import no.dcat.datastore.domain.dcat.builders.DatasetBuilder;
+import no.dcat.datastore.domain.dcat.client.LoadLocations;
+import no.dcat.datastore.domain.dcat.vocabulary.AdmEnhet;
+import no.dcat.datastore.domain.dcat.vocabulary.GeoNames;
 import no.dcat.shared.SkosCode;
 import no.dcat.shared.Types;
 import no.dcat.themes.database.TDBConnection;
@@ -10,6 +13,10 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Scope;
@@ -18,6 +25,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,13 +65,40 @@ public class CodesService extends BaseServiceWithFraming {
 
         return tdbConnection.inTransaction(ReadWrite.READ, connection -> {
             Dataset dataset = DatasetFactory.create(connection.getModelWithInference(type.toString()));
+            List<SkosCode> result = new ArrayList<>();
 
-            String json = frame(dataset, frame);
-            dataset.close();
+            if (type.equals(Types.location)) {
+                Model model = dataset.getDefaultModel();
 
-            return new Gson().fromJson(json, FramedSkosCode.class).getGraph();
+                result.addAll(extractLocationCodes(model, model.listResourcesWithProperty(GeoNames.officialName)));
+                result.addAll(extractLocationCodes(model, model.listResourcesWithProperty(RDF.type, AdmEnhet.NamedIndividual)));
+
+            } else {
+                String json = frame(dataset, frame);
+                dataset.close();
+
+                result = new Gson().fromJson(json, FramedSkosCode.class).getGraph();
+            }
+
+            return result;
         });
 
+    }
+
+    List<SkosCode> extractLocationCodes(Model model, ResIterator resourceIterator) {
+        if (model == null || resourceIterator == null) {
+            return null;
+        }
+
+
+        List<SkosCode> result = new ArrayList<>();
+
+        while (resourceIterator.hasNext()) {
+            Resource resource = resourceIterator.next();
+            result.add(DatasetBuilder.extractLocation(resource));
+        }
+
+        return result;
     }
 
 

--- a/applications/reference-data/src/test/java/no/dcat/themes/builders/LocationIT.java
+++ b/applications/reference-data/src/test/java/no/dcat/themes/builders/LocationIT.java
@@ -1,27 +1,34 @@
 package no.dcat.themes.builders;
 
 import no.dcat.shared.SkosCode;
+import no.dcat.shared.Types;
 import no.dcat.shared.testcategories.IntegrationTest;
 import no.dcat.themes.database.TDBConnection;
 import no.dcat.themes.database.TDBInferenceService;
 import no.dcat.themes.database.TDBService;
 import no.dcat.themes.service.CodesService;
+import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
- * Test class for CodeBuildersTest
+ * Tests to check that location uris can be handled correctly by reference data service.
+ *
  */
 @Category(IntegrationTest.class)
 public class LocationIT {
+    private static Logger logger = LoggerFactory.getLogger(LocationIT.class);
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
@@ -76,6 +83,16 @@ public class LocationIT {
         assertEquals("Norge", code.getPrefLabel().get("no"));
     }
 
+    @Test
+    public void testExtractionFromLocation () throws Throwable {
+        testOsloFromGeonames2();
+        testGeonorgeFylke();
+        testGeonorgeKommune();
+        testGeonorgeNasjon();
 
+        List<SkosCode> actual = codesService.getCodes(Types.location);
+
+        assertThat(actual.size(), Matchers.is(4));
+    }
 
 }

--- a/applications/search/src/pages/search-page/results-dataset/__snapshots__/results-dataset.component.test.jsx.snap
+++ b/applications/search/src/pages/search-page/results-dataset/__snapshots__/results-dataset.component.test.jsx.snap
@@ -207,6 +207,25 @@ exports[`should render ResultsDataset correctly with hits 1`] = `
                       "buckets": Array [
                         Object {
                           "doc_count": 1,
+                          "key": "Ukjent",
+                        },
+                      ],
+                      "doc_count_error_upper_bound": 0,
+                      "sum_other_doc_count": 0,
+                    }
+                  }
+                  htmlKey={3}
+                  onClick={null}
+                  themesItems={null}
+                  title="Geografi"
+                />
+                <FilterBox
+                  activeFilter={null}
+                  filter={
+                    Object {
+                      "buckets": Array [
+                        Object {
+                          "doc_count": 1,
                           "key": "VEDTAK",
                         },
                       ],
@@ -320,6 +339,25 @@ exports[`should render ResultsDataset correctly with hits 1`] = `
             orgPath={null}
             publishers={Object {}}
             title="Virksomhet"
+          />
+          <FilterBox
+            activeFilter={null}
+            filter={
+              Object {
+                "buckets": Array [
+                  Object {
+                    "doc_count": 1,
+                    "key": "Ukjent",
+                  },
+                ],
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+              }
+            }
+            htmlKey={3}
+            onClick={null}
+            themesItems={null}
+            title="Geografi"
           />
           <FilterBox
             activeFilter={null}

--- a/applications/search/src/pages/search-page/results-dataset/results-dataset.component.jsx
+++ b/applications/search/src/pages/search-page/results-dataset/results-dataset.component.jsx
@@ -55,14 +55,13 @@ export class ResultsDataset extends React.Component {
               activeFilter={searchQuery.orgPath}
               publishers={publishers}
             />
-            {/* geography filter section temporarily removed */}
-            {/* <FilterBox */}
-            {/* htmlKey={3} */}
-            {/* title={localization.facet.spatial} */}
-            {/* filter={datasetItems.aggregations.spatial} */}
-            {/* onClick={onFilterSpatial} */}
-            {/* activeFilter={searchQuery.spatial} */}
-            {/* /> */}
+            <FilterBox
+              htmlKey={3}
+              title={localization.facet.spatial}
+              filter={datasetItems.aggregations.spatial}
+              onClick={onFilterSpatial}
+              activeFilter={searchQuery.spatial}
+            />
             <FilterBox
               htmlKey={4}
               title={localization.facet.provenance}
@@ -209,14 +208,13 @@ export class ResultsDataset extends React.Component {
                       activeFilter={searchQuery.orgPath}
                       publishers={publishers}
                     />
-                    {/* Temporarily removed geography filter */}
-                    {/* <FilterBox */}
-                    {/* htmlKey={3} */}
-                    {/* title={localization.facet.spatial} */}
-                    {/* filter={datasetItems.aggregations.spatial} */}
-                    {/* onClick={onFilterSpatial} */}
-                    {/* activeFilter={searchQuery.spatial} */}
-                    {/* /> */}
+                    <FilterBox
+                      htmlKey={3}
+                      title={localization.facet.spatial}
+                      filter={datasetItems.aggregations.spatial}
+                      onClick={onFilterSpatial}
+                      activeFilter={searchQuery.spatial}
+                    />
                     <FilterBox
                       htmlKey={4}
                       title={localization.facet.provenance}

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DcatReader.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DcatReader.java
@@ -42,7 +42,7 @@ public class DcatReader {
         if (codes.get("location") != null) {
             locations = codes.get("location");
         } else {
-            locations = new HashMap<String, SkosCode>();
+            locations = new HashMap<>();
         }
 
         LoadLocations loadLocations = new LoadLocations(codeServiceHost, httpUsername, httpPassword);

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
@@ -49,6 +49,9 @@ public class LoadLocations {
         httpUsername = null;
     }
 
+    public SkosCode getLocation(String uri) {
+        return locations.get(uri);
+    }
 
     /**
      * Extracts all location-uris from the model and adds it to the map of locations.
@@ -71,18 +74,23 @@ public class LoadLocations {
                 if (uri != null && uri.startsWith("http")) {
                     if (existingLocationCodes == null || !existingLocationCodes.containsKey(uri)) {
 
-                        LocationUri locationUri = new LocationUri(uri);
-
-                        try {
-                            SkosCode skosCode = template.postForObject(themesHostname + "/locations/", locationUri, SkosCode.class);
-                            locations.put(skosCode.getUri(), skosCode);
-                        } catch (Exception e) {
-                            logger.error("Error posting location [{}] to reference-data service. Reason {}", locationUri.getUri(), e.getLocalizedMessage());
-                        }
+                        postLocationToReferenceData(template, uri);
                     }
                 }
             });
         });
+    }
+
+    public void postLocationToReferenceData(BasicAuthRestTemplate template, String uri) {
+        LocationUri locationUri = new LocationUri(uri);
+
+        try {
+            SkosCode skosCode = template.postForObject(themesHostname + "/locations/", locationUri, SkosCode.class);
+            locations.put(skosCode.getUri(), skosCode);
+            logger.info("Posting location to reference-data: {}", skosCode.toString());
+        } catch (Exception e) {
+            logger.error("Error posting location [{}] to reference-data service. Reason {}", locationUri.getUri(), e.getLocalizedMessage());
+        }
     }
 
 

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/vocabulary/AdmEnhet.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/vocabulary/AdmEnhet.java
@@ -23,4 +23,6 @@ public class AdmEnhet {
 	
 	public static final Property nasjonnavn = model.createProperty(NS, "nasjonnavn");
 
+	public static final Resource NamedIndividual = model.createResource("http://www.w3.org/2002/07/owl#NamedIndividual");
+
 }


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/FDK-1149

Har gjort om reference-data til å returnere geolokasjoner. dette gjorde den ikke før da framing-koden som var benyttet ikke tok hensyn til geonorge data. Har nå laget eksplisitt kode for geolokasjon. Har testet dette lokalt og håper det blir riktig. Både reference-data og harvester-api er berørt. 

> check applicable boxes

- [x] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
