### PR TITLE
Temporal and spatial are now exported in catalog sparql

### DIFF
--- a/applications/search-api/src/main/resources/sparql/catalog.sparql
+++ b/applications/search-api/src/main/resources/sparql/catalog.sparql
@@ -9,7 +9,7 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix vcard: <http://www.w3.org/2006/vcard/ns#>
 prefix er: <http://data.brreg.no/meta/>
 
-DESCRIBE ?publisher ?dataset ?distribution ?catalog ?contact
+DESCRIBE ?publisher ?dataset ?distribution ?catalog ?contact ?temporal ?spatial
 WHERE {
   ?catalog a dcat:Catalog;
   dct:publisher ?publisher;
@@ -17,6 +17,8 @@ WHERE {
 
   OPTIONAL {?dataset dcat:distribution ?distribution}
   OPTIONAL {?dataset dcat:contactPoint ?contact}
+  OPTIONAL {?dataset dct:temporal ?temporal}
+  OPTIONAL {?dataset dct:spatial ?spatial}
 
   FILTER (?catalog = <%s>)
 


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/FDK-1203

Fikset SPARQL dESCRIBE spørreing til å returnere hele temporal objekter.

> check applicable boxes

- [ ] I have made tests to match the user stories
- [x] This code does not require tests that match user stories
