### PR TITLE
(search) Restore loading themes, publishers and distributiontypes in …

### DIFF
--- a/applications/search/src/pages/search-page/search-page.jsx
+++ b/applications/search/src/pages/search-page/search-page.jsx
@@ -55,6 +55,9 @@ export class SearchPage extends React.Component {
 
     this.props.fetchDatasetsIfNeeded(`/datasets${search}`);
     this.props.fetchTermsIfNeeded(`/terms${search}`);
+    this.props.fetchThemesIfNeeded();
+    this.props.fetchPublishersIfNeeded();
+    this.props.fetchDistributionTypeIfNeeded();
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
…search page

It was lost in 2a8fc698 (search) Remove search broadening implementation from frontend ("abc" -> "abc abc*")

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
