### PR TITLE
API-135 fixed bug causing wrong title sort order

### DIFF
--- a/applications/search-api/src/main/java/no/dcat/portal/query/DatasetsQueryService.java
+++ b/applications/search-api/src/main/java/no/dcat/portal/query/DatasetsQueryService.java
@@ -240,13 +240,14 @@ public class DatasetsQueryService extends ElasticsearchService {
 
         logger.trace("Query: {}", searchBuilder.toString());
 
-        if (emptySearch) {
-            addSortForEmptySearch(searchBuilder);
-        }
 
         // Handle attempting to sort on score, because any sorting removes score i.e. relevance from the search.
         if (sortfield.compareTo("score") != 0) {
             addSort(sortfield, sortdirection, searchBuilder);
+        }
+
+        if (emptySearch) {
+            addSortForEmptySearch(searchBuilder);
         }
 
         // Execute search


### PR DESCRIPTION
When no search string is specified, title sort order was appended to the end of default sort (provenance, source, change date).
Changed this to append default sort order after user-requested sort order.

<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-135

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
