### PR TITLE
Feature/bg/apicatalog sort

### DIFF
--- a/applications/api-cat/src/main/java/no/acat/restapi/SearchController.java
+++ b/applications/api-cat/src/main/java/no/acat/restapi/SearchController.java
@@ -12,10 +12,16 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 
 @CrossOrigin
 @RestController
@@ -59,10 +65,20 @@ public class SearchController {
 
             @ApiParam("Specifies the size, i.e. the number of datasets to return in one request. The default is 10, the maximum number of datasets returned is 100")
             @RequestParam(value = "size", defaultValue = "10", required = false)
-                    int size
-    ) {
+                    int size,
+
+            @ApiParam("Specifies the sort field, at the present we support title, modified and publisher. Default is no value")
+            @RequestParam(value = "sortfield", defaultValue = "", required = false) String sortfield,
+
+
+            @ApiParam("Specifies the sort direction of the sorted result. The directions are: asc for ascending and desc for descending")
+            @RequestParam(value = "sortdirection", defaultValue = "", required = false) String sortdirection
+
+            ) {
         try {
             SearchRequestBuilder searchRequest = buildSearchRequest(query, accessRights, orgPath, formats, from, size);
+            addSort(sortfield, sortdirection, searchRequest);
+
             SearchResponse elasticResponse = doQuery(searchRequest);
             return convertFromElasticResponse(elasticResponse);
         } catch (Exception e) {
@@ -127,6 +143,32 @@ public class SearchController {
             boolQuery.filter(QueryBuilders.termQuery(term, value));
         }
     }
+
+
+    private void addSort(String sortfield, String sortdirection, SearchRequestBuilder searchBuilder) {
+
+        //Key is search field in request from client
+        //Value is actual search field in acat index, as acat datamodel is different from dcat datamodel
+        //also, sort must use unanalyzed fields
+        HashMap<String,String> allowedSearchFields = new HashMap<String,String>();
+        allowedSearchFields.put("title.nn", "title.no.raw");
+        allowedSearchFields.put("title.nb", "title.no.raw");
+        allowedSearchFields.put("title.no", "title.no.raw");
+        allowedSearchFields.put("publisher.name", "publisher.prefLabel.no.keyword");
+
+        //ony allow sorting on field contained in map. Other fields are ignored
+        if(allowedSearchFields.containsKey(sortfield)) {
+            SortOrder sortOrder = sortdirection.toLowerCase().contains("asc".toLowerCase()) ? SortOrder.ASC : SortOrder.DESC;
+            StringBuilder sbSortField = new StringBuilder();
+
+            sbSortField.append(allowedSearchFields.get(sortfield));
+
+            logger.debug("Added sortfield: {} with sort direction {}", sbSortField.toString(), sortOrder.toString() );
+
+            searchBuilder.addSort(sbSortField.toString(), sortOrder);
+        }
+    }
+
 
     private int checkAndAdjustFrom(int from) {
         if (from < 0) {

--- a/applications/api-cat/src/main/resources/apispec.mapping.json
+++ b/applications/api-cat/src/main/resources/apispec.mapping.json
@@ -16,10 +16,37 @@
               }
             }
           },
+          "prefLabel": {
+            "properties": {
+              "no": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          },
           "orgPath": {
             "type": "text",
             "fielddata": "true",
             "analyzer": "path-analyzer"
+          }
+        }
+      },
+      "title": {
+        "properties": {
+          "no": {
+            "analyzer": "norwegian",
+            "type": "string",
+            "fields": {
+              "raw": {
+                "type": "string",
+                "index": "not_analyzed"
+              }
+            }
           }
         }
       },

--- a/applications/api-cat/src/test/java/no/acat/restapi/SearchControllerTest.java
+++ b/applications/api-cat/src/test/java/no/acat/restapi/SearchControllerTest.java
@@ -46,7 +46,7 @@ public class SearchControllerTest {
         when(hit.getSourceAsString()).thenReturn(apiSpecExample);
         when(hit.getId()).thenReturn("http://testtesttset");
 
-        QueryResponse response = spyController.search("","","",new String[]{""},0,0);
+        QueryResponse response = spyController.search("","","",new String[]{""},0,0, "", "");
 
         assertThat(response, notNullValue());
 


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-157

Backend support for sort in api catalog.
Frontend sends sort requests based on dcat data model, so this had to be mapped to the acat data model:
* Title sort: Mapping title.nb -> title.no.raw
* Publisher name sort: Mapping publisher.name -> publisher.prefLabel.no.keyword
* modified date sort: Not implemented, as api descriptions currently lacks modified date information.

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
