### PR TITLE
(api-cat) API-304 default sort is now on proventance

### DIFF
--- a/applications/api-cat/src/main/java/no/acat/harvester/ApiDocumentBuilder.java
+++ b/applications/api-cat/src/main/java/no/acat/harvester/ApiDocumentBuilder.java
@@ -101,6 +101,7 @@ public class ApiDocumentBuilder {
         apiDocument.setProvenance(extractProvenance(apiCatalogRecord));
         apiDocument.setDatasetReferences(extractDatasetReferences(apiCatalogRecord));
         apiDocument.setApiDocUrl(apiCatalogRecord.getApiDocUrl());
+        apiDocument.setProvenanceSort(createProvenanceSort(apiDocument.getProvenance()));
     }
 
     String lookupOrGenerateId(ApiCatalogRecord apiCatalogRecord) {
@@ -258,6 +259,32 @@ public class ApiDocumentBuilder {
             }));
         });
         return formats;
+    }
+
+
+    /**
+     * Create string that allows simples string sorting of provenance
+     *
+     * @param provenanceCode Skos code with provenance value
+     */
+    String createProvenanceSort(SkosCode provenanceCode) {
+        String sortString = "";
+
+        final String provenanceValue = provenanceCode != null ? provenanceCode.getCode() : null;
+
+        if ("NASJONAL".equals(provenanceValue)) {
+            sortString = "1NASJONAL";
+        } else if ("VEDTAK".equals(provenanceValue)) {
+            sortString = "2VEDTAK";
+        } else if ("BRUKER".equals(provenanceValue)) {
+            sortString = "3BRUKER";
+        } else if ("TREDJEPART".equals(provenanceValue)) {
+            sortString = "4TREDJEPART";
+        } else {
+            sortString = "9UKJENT";
+        }
+
+        return sortString;
     }
 
 }

--- a/applications/api-cat/src/main/java/no/acat/model/ApiDocument.java
+++ b/applications/api-cat/src/main/java/no/acat/model/ApiDocument.java
@@ -67,4 +67,7 @@ public class ApiDocument  {
 
     @ApiModelProperty("The url of the API documentation")
     private String apiDocUrl;
+
+    @ApiModelProperty("Transformed version of provenance property that allows sorting on provenance by using simple string sort")
+    private String provenanceSort;
 }

--- a/applications/api-cat/src/main/java/no/acat/restapi/SearchController.java
+++ b/applications/api-cat/src/main/java/no/acat/restapi/SearchController.java
@@ -12,6 +12,8 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +80,9 @@ public class SearchController {
         try {
             SearchRequestBuilder searchRequest = buildSearchRequest(query, accessRights, orgPath, formats, from, size);
             addSort(sortfield, sortdirection, searchRequest);
+            if(query.isEmpty()) {
+                addSortForEmptySearch(searchRequest);
+            }
 
             SearchResponse elasticResponse = doQuery(searchRequest);
             return convertFromElasticResponse(elasticResponse);
@@ -167,6 +172,18 @@ public class SearchController {
 
             searchBuilder.addSort(sbSortField.toString(), sortOrder);
         }
+    }
+
+
+    /**
+     * create default sort order - national components should appear first
+     *
+     */
+    void addSortForEmptySearch(SearchRequestBuilder searchBuilder) {
+        SortBuilder sortFieldProvenance = SortBuilders.fieldSort("provenanceSort")
+                .order(SortOrder.ASC);
+
+        searchBuilder.addSort(sortFieldProvenance);
     }
 
 

--- a/applications/api-cat/src/main/resources/apispec.mapping.json
+++ b/applications/api-cat/src/main/resources/apispec.mapping.json
@@ -62,6 +62,10 @@
       },
       "openApi": {
         "enabled": "false"
+      },
+      "provenanceSort": {
+        "type": "string",
+        "index": "not_analyzed"
       }
     }
   }

--- a/applications/api-cat/src/test/java/no/acat/harvester/ApiDocumentBuilderTest.java
+++ b/applications/api-cat/src/test/java/no/acat/harvester/ApiDocumentBuilderTest.java
@@ -1,0 +1,65 @@
+package no.acat.harvester;
+
+import no.acat.service.ElasticsearchService;
+import no.acat.service.ReferenceDataService;
+import no.dcat.client.referencedata.ReferenceDataClient;
+import org.elasticsearch.client.Client;
+import no.dcat.shared.SkosCode;
+import no.dcat.shared.testcategories.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Created by bjg on 26.09.2018.
+ */
+@Category(UnitTest.class)
+public class ApiDocumentBuilderTest {
+
+
+    @Test
+    public void createProvenanceSortNational() {
+
+        Client elasticsearchClient = mock(Client.class);
+        ReferenceDataClient referencedataClient =mock(ReferenceDataClient.class);
+
+        ApiDocumentBuilder builder = new ApiDocumentBuilder(elasticsearchClient, referencedataClient, "http://some.url");
+
+        SkosCode provenanceCode = new SkosCode();
+        provenanceCode.setCode("NASJONAL");
+
+        assertThat(builder.createProvenanceSort(provenanceCode), is("1NASJONAL"));
+    }
+
+
+    @Test
+    public void createProvenanceSortVedtak() {
+
+        Client elasticsearchClient = mock(Client.class);
+        ReferenceDataClient referencedataClient =mock(ReferenceDataClient.class);
+
+        ApiDocumentBuilder builder = new ApiDocumentBuilder(elasticsearchClient, referencedataClient, "http://some.url");
+
+        SkosCode provenanceCode = new SkosCode();
+        provenanceCode.setCode("VEDTAK");
+
+        assertThat(builder.createProvenanceSort(provenanceCode), is("2VEDTAK"));
+    }
+
+    @Test
+    public void createProvenanceSortNoCodeSupplied() {
+
+        Client elasticsearchClient = mock(Client.class);
+        ReferenceDataClient referencedataClient =mock(ReferenceDataClient.class);
+
+        ApiDocumentBuilder builder = new ApiDocumentBuilder(elasticsearchClient, referencedataClient, "http://some.url");
+
+        //no code set
+        SkosCode provenanceCode = new SkosCode();
+
+        assertThat(builder.createProvenanceSort(provenanceCode), is("9UKJENT"));
+    }
+}

--- a/applications/api-cat/src/test/java/no/acat/restapi/SearchControllerTest.java
+++ b/applications/api-cat/src/test/java/no/acat/restapi/SearchControllerTest.java
@@ -40,6 +40,7 @@ public class SearchControllerTest {
 
         doReturn(null).when(spyController).buildSearchRequest(anyString(),anyString(),anyString(),any(),anyInt(),anyInt());
         doReturn(searchResponse).when(spyController).doQuery(anyObject());
+        doNothing().when(spyController).addSortForEmptySearch(anyObject());
         // todo this is nonsense, we do not test anything
         doReturn(new QueryResponse()).when(spyController).convertFromElasticResponse(anyObject());
 


### PR DESCRIPTION
APIs with provenance NATIONAL appears first in search results

<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-304

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
