### PR TITLE
(registration-react) refactor component list-item to accept path as p…

### DIFF
--- a/applications/registration-react/src/components/list-items/__snapshots__/list-items.test.jsx.snap
+++ b/applications/registration-react/src/components/list-items/__snapshots__/list-items.test.jsx.snap
@@ -37,30 +37,16 @@ exports[`should render ListItem correctly with props 1`] = `
     </div>
   </div>
   <ListItem
-    catalogId="123"
-    item={
-      Object {
-        "id": 1,
-        "registrationStatus": "DRAFT",
-        "title": Object {
-          "nb": "Test item",
-        },
-      }
-    }
     key="1"
+    path="/catalogs/123/datasets/1"
+    status="DRAFT"
+    title="Test item"
   />
   <ListItem
-    catalogId="123"
-    item={
-      Object {
-        "id": 2,
-        "registrationStatus": "PUBLISH",
-        "title": Object {
-          "nb": "Test item",
-        },
-      }
-    }
     key="2"
+    path="/catalogs/123/datasets/2"
+    status="PUBLISH"
+    title="Test item"
   />
 </div>
 `;

--- a/applications/registration-react/src/components/list-items/list-item/__snapshots__/list-item.test.jsx.snap
+++ b/applications/registration-react/src/components/list-items/list-item/__snapshots__/list-item.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`should render ListItem correctly "DRAFT" item 1`] = `
 <div
-  className="fdk-datasets-list-item d-flex"
+  className="fdk-list-item d-flex"
 >
   <Link
     className="w-100"
@@ -36,7 +36,7 @@ exports[`should render ListItem correctly "DRAFT" item 1`] = `
 
 exports[`should render ListItem correctly "PUBLISH" item 1`] = `
 <div
-  className="fdk-datasets-list-item d-flex"
+  className="fdk-list-item d-flex"
 >
   <Link
     className="w-100"
@@ -70,7 +70,7 @@ exports[`should render ListItem correctly "PUBLISH" item 1`] = `
 
 exports[`should render ListItem correctly when missing title 1`] = `
 <div
-  className="fdk-datasets-list-item d-flex"
+  className="fdk-list-item d-flex"
 >
   <Link
     className="w-100"

--- a/applications/registration-react/src/components/list-items/list-item/list-item.component.jsx
+++ b/applications/registration-react/src/components/list-items/list-item/list-item.component.jsx
@@ -2,42 +2,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import cx from 'classnames';
-import _ from 'lodash';
 
 import localization from '../../../utils/localization';
-import getTranslateText from '../../../utils/translateText';
 import './list-item.scss';
 
 export const ListItem = props => {
-  const { catalogId, item } = props;
+  const { title, status, path } = props;
 
-  if (!item) {
+  if (!(title || status)) {
     return null;
   }
 
   const itemClass = cx('w-75', 'fdk-text-size-small', {
-    'fdk-color2': item && !getTranslateText(_.get(item, 'title'))
+    'fdk-color2': !title
   });
 
   return (
-    <div className="fdk-datasets-list-item d-flex">
-      <Link className="w-100" to={`/catalogs/${catalogId}/datasets/${item.id}`}>
+    <div className="fdk-list-item d-flex">
+      <Link className="w-100" to={path}>
         <div className="d-flex justify-content-between">
           <span className={itemClass}>
-            {getTranslateText(_.get(item, 'title')) ||
-              localization.datasets.list.missingTitle}
+            {title || localization.listItems.missingTitle}
           </span>
           <span className="d-flex w-25">
-            {_.get(item, 'registrationStatus') === 'PUBLISH' && (
+            {status === 'PUBLISH' && (
               <span>
                 <i className="fa fa-circle fdk-color-cta mr-2" />
-                <span>{localization.datasets.list.statusPublished}</span>
+                <span>{localization.listItems.statusPublished}</span>
               </span>
             )}
-            {_.get(item, 'registrationStatus') === 'DRAFT' && (
+            {status === 'DRAFT' && (
               <span>
                 <i className="fa fa-circle fdk-color3 mr-2" />
-                <span>{localization.datasets.list.statusDraft}</span>
+                <span>{localization.listItems.statusDraft}</span>
               </span>
             )}
           </span>
@@ -48,10 +45,13 @@ export const ListItem = props => {
 };
 
 ListItem.defaultProps = {
-  item: null
+  title: null,
+  status: null,
+  path: null
 };
 
 ListItem.propTypes = {
-  catalogId: PropTypes.string.isRequired,
-  item: PropTypes.object
+  title: PropTypes.string,
+  status: PropTypes.string,
+  path: PropTypes.string
 };

--- a/applications/registration-react/src/components/list-items/list-item/list-item.scss
+++ b/applications/registration-react/src/components/list-items/list-item/list-item.scss
@@ -1,6 +1,6 @@
 @import '../../../../node_modules/designsystemet/fdk-designsystem-bootstrap4/scss/colors.scss';
 
-.fdk-datasets-list-item {
+.fdk-list-item {
   background-color: $color0;
   margin-bottom: .3em;
   border-radius: 3px;

--- a/applications/registration-react/src/components/list-items/list-item/list-item.test.jsx
+++ b/applications/registration-react/src/components/list-items/list-item/list-item.test.jsx
@@ -17,40 +17,27 @@ test('should render ListItem correctly with no props', () => {
 });
 
 test('should render ListItem correctly "DRAFT" item', () => {
-  const draftItem = {
-    id: 1,
-    title: {
-      nb: 'Test item'
-    },
-    registrationStatus: 'DRAFT'
-  };
   wrapper.setProps({
-    item: draftItem
+    title: 'Test item',
+    status: 'DRAFT',
+    path: '/catalogs/123/datasets/1'
   });
   expect(wrapper).toMatchSnapshot();
 });
 
 test('should render ListItem correctly "PUBLISH" item', () => {
-  const publishItem = {
-    id: 1,
-    title: {
-      nb: 'Test item'
-    },
-    registrationStatus: 'PUBLISH'
-  };
   wrapper.setProps({
-    item: publishItem
+    title: 'Test item',
+    status: 'PUBLISH',
+    path: '/catalogs/123/datasets/1'
   });
   expect(wrapper).toMatchSnapshot();
 });
 
 test('should render ListItem correctly when missing title', () => {
-  const missingTitleItem = {
-    id: 1,
-    registrationStatus: 'DRAFT'
-  };
   wrapper.setProps({
-    item: missingTitleItem
+    status: 'DRAFT',
+    path: '/catalogs/123/datasets/1'
   });
   expect(wrapper).toMatchSnapshot();
 });

--- a/applications/registration-react/src/components/list-items/list-items.component.jsx
+++ b/applications/registration-react/src/components/list-items/list-items.component.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import orderBy from 'lodash/orderBy';
+import _ from 'lodash';
 
 import localization from '../../utils/localization';
 import SortButtons from '../sort-button/sort-button.component';
 import { ListItem } from './list-item/list-item.component';
+import getTranslateText from '../../utils/translateText';
 
 const renderDatasetItems = (catalogId, items, sortField, sortType) => {
   if (items) {
@@ -29,7 +31,12 @@ const renderDatasetItems = (catalogId, items, sortField, sortType) => {
     }
 
     return sortedItems.map(item => (
-      <ListItem key={item.id} catalogId={catalogId} item={item} />
+      <ListItem
+        key={item.id}
+        title={getTranslateText(_.get(item, 'title'))}
+        status={_.get(item, 'registrationStatus')}
+        path={`/catalogs/${catalogId}/datasets/${item.id}`}
+      />
     ));
   }
   return (

--- a/applications/registration-react/src/l10n/en.json
+++ b/applications/registration-react/src/l10n/en.json
@@ -1,4 +1,9 @@
 {
+  "listItems": {
+    "missingTitle": "Missing title",
+    "statusPublished": "Published",
+    "statusDraft": "Draft"
+  },
   "app": {
     "skipLink": "Skip link",
     "navigateFrontpage": "Navigate to frontpage",
@@ -267,10 +272,7 @@
         "title": "Dataset title",
         "status": "Status"
       },
-      "missingItems": "No dataset description registered",
-      "missingTitle": "Missing title",
-      "statusPublished": "Published",
-      "statusDraft": "Draft"
+      "missingItems": "No dataset description registered"
     },
     "import": {
       "notEmpty": "URL can't be empty",

--- a/applications/registration-react/src/l10n/nb.json
+++ b/applications/registration-react/src/l10n/nb.json
@@ -1,4 +1,9 @@
 {
+  "listItems": {
+    "missingTitle": "Mangler tittel",
+    "statusPublished": "Publisert",
+    "statusDraft": "Utkast"
+  },
   "app": {
     "skipLink": "Hopp til hovedinnhold",
     "navigateFrontpage": "Gå til forside",
@@ -267,10 +272,7 @@
         "title": "Tittel på datasett",
         "status": "Status"
       },
-      "missingItems": "Ingen datasettbeskrivelse registrert",
-      "missingTitle": "Mangler tittel",
-      "statusPublished": "Publisert",
-      "statusDraft": "Utkast"
+      "missingItems": "Ingen datasettbeskrivelse registrert"
     },
     "import": {
       "notEmpty": "URL kan ikke være tom",


### PR DESCRIPTION
…rop, update usage

(cherry picked from commit 44a671c)

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories

Refactor to make list-item independent of dataset, accept path as prop and rename classname