### PR TITLE
api-cat-client

### DIFF
--- a/applications/api-cat/pom.xml
+++ b/applications/api-cat/pom.xml
@@ -153,6 +153,11 @@
             <artifactId>gson</artifactId>
             <version>2.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>no.dcat</groupId>
+            <artifactId>api-cat-client</artifactId>
+            <version>1.0.0</version>
+        </dependency>
 
     </dependencies>
 

--- a/applications/api-cat/src/main/java/no/acat/restapi/ConvertController.java
+++ b/applications/api-cat/src/main/java/no/acat/restapi/ConvertController.java
@@ -3,10 +3,10 @@ package no.acat.restapi;
 import com.google.common.base.Strings;
 import io.swagger.v3.oas.models.OpenAPI;
 import lombok.AllArgsConstructor;
-import no.acat.model.ConvertRequest;
-import no.acat.model.ConvertResponse;
 import no.acat.spec.ParseException;
 import no.acat.spec.Parser;
+import no.dcat.client.apicat.ConvertRequest;
+import no.dcat.client.apicat.ConvertResponse;
 import no.dcat.webutils.exceptions.BadRequestException;
 import org.springframework.web.bind.annotation.*;
 

--- a/libraries/api-cat-client/pom.xml
+++ b/libraries/api-cat-client/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.5.RELEASE</version>
+        <relativePath/>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>no.dcat</groupId>
+    <artifactId>api-cat-client</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>no.dcat</groupId>
+            <artifactId>shared</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>4.3.10.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.0.3</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/libraries/api-cat-client/src/main/java/no/dcat/client/apicat/ApiCatClient.java
+++ b/libraries/api-cat-client/src/main/java/no/dcat/client/apicat/ApiCatClient.java
@@ -1,0 +1,49 @@
+package no.dcat.client.apicat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+
+public class ApiCatClient {
+    private String apiCatUrl;
+
+    public ApiCatClient(String apiCatUrl) {
+        this.apiCatUrl = apiCatUrl;
+    }
+
+    public OpenAPI convert(String url, String spec) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        ConvertRequest request = ConvertRequest.builder()
+                .url(url)
+                .spec(spec)
+                .build();
+
+        HttpEntity<ConvertRequest> entity = new HttpEntity<>(request);
+
+        ConvertResponse convertResponse = restTemplate.exchange(this.apiCatUrl + "/convert", HttpMethod.POST, entity, ConvertResponse.class).getBody();
+
+        OpenAPI openAPI = convertResponse.openApi;
+
+        if (openAPI == null) {
+            throw new Error("Conversion error: " + getMessage(convertResponse));
+        }
+
+        return openAPI;
+    }
+
+    static String getMessage(ConvertResponse response) {
+        if (response.getMessages() != null) {
+            if (response.getMessages().size() == 1) {
+                return response.getMessages().get(0);
+            } else {
+                return response.getMessages().toString();
+            }
+        } else {
+            return "Unknown error";
+        }
+
+    }
+}
+

--- a/libraries/api-cat-client/src/main/java/no/dcat/client/apicat/ConvertRequest.java
+++ b/libraries/api-cat-client/src/main/java/no/dcat/client/apicat/ConvertRequest.java
@@ -1,8 +1,10 @@
-package no.acat.model;
+package no.dcat.client.apicat;
 
 
+import lombok.Builder;
 import lombok.Data;
 
+@Builder
 @Data
 public class ConvertRequest {
 

--- a/libraries/api-cat-client/src/main/java/no/dcat/client/apicat/ConvertResponse.java
+++ b/libraries/api-cat-client/src/main/java/no/dcat/client/apicat/ConvertResponse.java
@@ -1,4 +1,4 @@
-package no.acat.model;
+package no.dcat.client.apicat;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import lombok.Data;

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -17,6 +17,7 @@
         <module>elasticsearch5-test</module>
         <module>referencedata-client</module>
         <module>webutils-spring</module>
+        <module>api-cat-client</module>
     </modules>
 
 </project>


### PR DESCRIPTION
I api registrasjon, bruker kan gi api spesifikasjon som tekst eller som url.
Det er bestemt at api-cat tjeneste tilbyr parse funksion til å konvertere ulike formater inni intern api model. 

Siden api-cat allerede hadde intern parse og url download implementert, det eneste såm gjenstå å gjøre var til å eksponere de som to rest endepunkter.

I tillegg, lage en klient-bibliotek, til å få enkle bruk av tjenester.