### PR TITLE
(api-cat) Use harvestSourceUrl as synchronization key instead of apiSpecUrl

### DIFF
--- a/applications/api-cat/pom.xml
+++ b/applications/api-cat/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>no.dcat</groupId>
             <artifactId>registration-api-client</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
     </dependencies>

--- a/applications/api-cat/src/main/java/no/acat/model/ApiDocument.java
+++ b/applications/api-cat/src/main/java/no/acat/model/ApiDocument.java
@@ -16,8 +16,11 @@ import java.util.Set;
 @ToString(includeFieldNames = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiDocument {
-    @ApiModelProperty("The id given to the object by the harvest system")
+    @ApiModelProperty("The id given by the harvest system")
     private String id;
+
+    @ApiModelProperty("The source where the record was harvested from")
+    private String harvestSourceUri;
 
     @ApiModelProperty("The url of the specification which are used to harvest the specification ")
     private String apiSpecUrl;

--- a/applications/api-cat/src/main/resources/apidocument.mapping.json
+++ b/applications/api-cat/src/main/resources/apidocument.mapping.json
@@ -1,7 +1,7 @@
 {
   "apidocument": {
     "properties": {
-      "apiSpecUrl": {
+      "harvestSourceUri": {
         "type": "keyword"
       },
       "publisher": {

--- a/applications/api-cat/src/main/resources/apis.csv
+++ b/applications/api-cat/src/main/resources/apis.csv
@@ -1,12 +1,9 @@
-OrgNr;OrgName;ApiSpecUrl;ApiDocUrl;NationalComponent;DatasetRefs
-974760673;Brønnøysundregistrene;https://raw.githubusercontent.com/brreg/openAPI/master/specs/enhetsregisteret.json;https://data.brreg.no/enhetsregisteret/api/docs/index.html;true;http://brreg.no/catalogs/974760673/datasets/63086dda-9b72-43f0-bbc2-3ced4bc2edd6
-971035854;Universitetet i Oslo;https://docker-demo.fsat.no/fsapi/swagger.json;https://docker-demo.fsat.no/fsapi/swagger.html#!/person/get_personer_id;;
-971032146;KS;https://ks-no.github.io/api/innsyn-sok-api-v1.json;https://editor.swagger.io/?url=https://ks-no.github.io/api/innsyn-sok-api-v1.json;;
-970018131;Utdanningsdirektoratet;https://data-nor.udir.no/swagger/docs/v1.0;https://data.norge.no/data/utdanningsdirektoratet/nasjonalt-register-opplæringskontorer-nor;;
-970018131;Utdanningsdirektoratet;https://data-nbr.udir.no/swagger/docs/v1.0;https://data.norge.no/data/utdanningsdirektoratet/nasjonalt-barnehageregister-nbr;;
-970018131;Utdanningsdirektoratet;https://data-nsr.udir.no/swagger/docs/v1.0;https://data.norge.no/data/utdanningsdirektoratet/nasjonalt-skoleregister-nsr-0;;
-970018131;Utdanningsdirektoratet;https://data-nxr-fellestjeneste.udir.no/swagger/docs/v1;https://data.norge.no/data/utdanningsdirektoratet/nxr-fellestjeneste-0;;
-970018131;Utdanningsdirektoratet;http://www.barnehagefakta.no:80/swagger/docs/v1;https://data.norge.no/data/utdanningsdirektoratet/barnehagefakta-baf;;
-971032146;KS;https://play-with-fint.felleskomponent.no/administrasjon/personal/v2/api-docs;https://play-with-fint.felleskomponent.no/administrasjon/personal/swagger-ui.html;;
-974760673;Brønnøysundregistrene;https://raw.githubusercontent.com/brreg/openAPI/master/specs/fdk.json;https://github.com/Informasjonsforvaltning/fdk;;https://fellesdatakatalog.brreg.no/datasets/ea9e2aa7-880c-4387-888e-77446acab279
-974760673;Brønnøysundregistrene;https://raw.githubusercontent.com/brreg/openAPI/master/specs/api-cat.json;https://github.com/Informasjonsforvaltning/fdk;;
+Id;OrgNr;OrgName;ApiSpecUrl;ApiDocUrl;NationalComponent;DatasetRefs
+2;971035854;Universitetet i Oslo;https://docker-demo.fsat.no/fsapi/swagger.json;https://docker-demo.fsat.no/fsapi/swagger.html#!/person/get_personer_id;;
+3;971032146;KS;https://ks-no.github.io/api/innsyn-sok-api-v1.json;https://editor.swagger.io/?url=https://ks-no.github.io/api/innsyn-sok-api-v1.json;;
+4;970018131;Utdanningsdirektoratet;https://data-nor.udir.no/swagger/docs/v1.0;https://data.norge.no/data/utdanningsdirektoratet/nasjonalt-register-opplæringskontorer-nor;;
+5;970018131;Utdanningsdirektoratet;https://data-nbr.udir.no/swagger/docs/v1.0;https://data.norge.no/data/utdanningsdirektoratet/nasjonalt-barnehageregister-nbr;;
+6;970018131;Utdanningsdirektoratet;https://data-nsr.udir.no/swagger/docs/v1.0;https://data.norge.no/data/utdanningsdirektoratet/nasjonalt-skoleregister-nsr-0;;
+7;970018131;Utdanningsdirektoratet;https://data-nxr-fellestjeneste.udir.no/swagger/docs/v1;https://data.norge.no/data/utdanningsdirektoratet/nxr-fellestjeneste-0;;
+8;970018131;Utdanningsdirektoratet;http://www.barnehagefakta.no:80/swagger/docs/v1;https://data.norge.no/data/utdanningsdirektoratet/barnehagefakta-baf;;
+9;971032146;KS;https://play-with-fint.felleskomponent.no/administrasjon/personal/v2/api-docs;https://play-with-fint.felleskomponent.no/administrasjon/personal/swagger-ui.html;;

--- a/applications/api-cat/src/test/java/no/acat/harvester/ApiHarvestTest.java
+++ b/applications/api-cat/src/test/java/no/acat/harvester/ApiHarvestTest.java
@@ -28,7 +28,7 @@ public class ApiHarvestTest {
         ElasticsearchService elasticsearchServiceMock = mock(ElasticsearchService.class);
 
         ApiDocumentBuilderService apiDocumentBuilderServiceMock = mock(ApiDocumentBuilderService.class);
-        when(apiDocumentBuilderServiceMock.create(any())).thenReturn(new ApiDocument());
+        when(apiDocumentBuilderServiceMock.createFromApiRegistration(any(),any())).thenReturn(new ApiDocument());
 
         RegistrationApiClient registrationApiClientMock = mock(RegistrationApiClient.class);
         when(registrationApiClientMock.getPublished()).thenReturn(new ArrayList<>());
@@ -41,7 +41,7 @@ public class ApiHarvestTest {
         doNothing().when(spyHarvester).indexApi(any());
 
         List<ApiDocument> response = spyHarvester.harvestAll();
-        final int FROM_CSV = 11;
+        final int FROM_CSV = 8;
         assertThat(response.size(), is(FROM_CSV));
 
     }

--- a/applications/registration-api/pom.xml
+++ b/applications/registration-api/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>no.dcat</groupId>
             <artifactId>registration-api-client</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
     </dependencies>

--- a/libraries/registration-api-client/pom.xml
+++ b/libraries/registration-api-client/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>registration-api-client</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <dependencies>
         <dependency>

--- a/libraries/registration-api-client/src/main/java/no/dcat/client/registrationapi/RegistrationApiClient.java
+++ b/libraries/registration-api-client/src/main/java/no/dcat/client/registrationapi/RegistrationApiClient.java
@@ -14,18 +14,18 @@ import java.util.List;
 RegistrationApiClient is a library for consuming REST api with strong types.
  */
 public class RegistrationApiClient {
-    private String apiregistrationUrl;
+    private String apiRegistrationUrl;
     private Logger logger;
 
-    public RegistrationApiClient(String apiregistrationUrl, Logger logger) {
-        this.apiregistrationUrl = apiregistrationUrl;
+    public RegistrationApiClient(String apiRegistrationUrl, Logger logger) {
+        this.apiRegistrationUrl = apiRegistrationUrl;
         this.logger = logger;
     }
 
     public Collection<ApiRegistrationPublic> getPublished() {
 
         RestTemplate restTemplate = new RestTemplate();
-        String publishedHalJson = restTemplate.getForObject(this.apiregistrationUrl + "/public/apis", String.class);
+        String publishedHalJson = restTemplate.getForObject(getPublicApisUrlBase(), String.class);
         logger.debug("String response from public apis \"{}\"...", publishedHalJson.substring(0, 20));
 
         JsonParser parser = new JsonParser();
@@ -44,5 +44,9 @@ public class RegistrationApiClient {
         logger.debug("Converted list of public apis: {}", apiRegistrations.size());
 
         return apiRegistrations;
+    }
+
+    public String getPublicApisUrlBase() {
+        return apiRegistrationUrl + "/public/apis";
     }
 }


### PR DESCRIPTION
Der er noe ideer om harvest metadata oppdatering, men manuell tester feiler, så ikke ferdig ennå