### PR TITLE
Feature/ds/api 436 norwegian characters bug

### DIFF
--- a/applications/api-cat/pom.xml
+++ b/applications/api-cat/pom.xml
@@ -165,7 +165,13 @@
 
     <build>
         <plugins>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/applications/api-cat/src/main/java/no/acat/restapi/ConvertController.java
+++ b/applications/api-cat/src/main/java/no/acat/restapi/ConvertController.java
@@ -8,8 +8,6 @@ import no.acat.spec.Parser;
 import no.dcat.client.apicat.ConvertRequest;
 import no.dcat.client.apicat.ConvertResponse;
 import no.dcat.webutils.exceptions.BadRequestException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +19,6 @@ import java.util.List;
 @RestController
 @AllArgsConstructor
 public class ConvertController {
-    private static final Logger logger = LoggerFactory.getLogger(ConvertController.class);
 
     @RequestMapping("/convert")
     @PostMapping(produces = "application/json")
@@ -30,7 +27,6 @@ public class ConvertController {
         List<String> messages = new ArrayList();
         String spec = request.getSpec();
         String url = request.getUrl();
-        logger.debug("Starting convert spec:{}, url:{}", spec, url);
 
         if (Strings.isNullOrEmpty(spec) && Strings.isNullOrEmpty(url)) {
             throw new BadRequestException("Url or spec parameter is required");
@@ -54,6 +50,7 @@ public class ConvertController {
         if (messages.size() > 0) {
             responseBody.setMessages(messages);
         }
+
         return responseBody;
     }
 

--- a/applications/api-cat/src/main/java/no/acat/spec/Parser.java
+++ b/applications/api-cat/src/main/java/no/acat/spec/Parser.java
@@ -9,7 +9,6 @@ import no.acat.spec.converters.SwaggerJsonSpecConverter;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/applications/api-cat/src/main/java/no/acat/spec/converters/OpenApiV3JsonSpecConverter.java
+++ b/applications/api-cat/src/main/java/no/acat/spec/converters/OpenApiV3JsonSpecConverter.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import no.acat.config.Utils;
 import no.acat.spec.ParseException;
 
 import java.io.IOException;
 
 public class OpenApiV3JsonSpecConverter {
+
     public static boolean canConvert(String spec) {
         ObjectMapper mapper = Utils.jsonMapper();
         try {
@@ -24,7 +26,12 @@ public class OpenApiV3JsonSpecConverter {
 
     public static OpenAPI convert(String spec) throws ParseException {
         try {
-            return new OpenAPIV3Parser().readContents(spec, null, null).getOpenAPI();
+            SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readContents(spec, null, null);
+
+            if (swaggerParseResult.getOpenAPI() == null && (swaggerParseResult.getMessages().size()> 0)) {
+                throw new ParseException("Failed to parse document. Messages: " + String.join(" ", swaggerParseResult.getMessages()));
+            }
+            return swaggerParseResult.getOpenAPI();
         } catch (Error e) {
             throw new ParseException("Cannot import spec as OpenApi v3 json: " + e.getMessage());
         }

--- a/applications/api-cat/src/test/java/no/acat/restapi/ConvertControllerTest.java
+++ b/applications/api-cat/src/test/java/no/acat/restapi/ConvertControllerTest.java
@@ -1,0 +1,47 @@
+package no.acat.restapi;
+
+import no.dcat.client.apicat.ConvertRequest;
+import no.dcat.client.apicat.ConvertResponse;
+import no.dcat.shared.testcategories.UnitTest;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+@Category(UnitTest.class)
+@RunWith(SpringRunner.class)
+public class ConvertControllerTest {
+
+    private static Logger logger = LoggerFactory.getLogger(ConvertControllerTest.class);
+
+    @Test
+    public void readAndCheckUtf8() throws Throwable {
+        ClassPathResource resource = new ClassPathResource("raw-enhet-api.json");
+
+        String resourceUrl = resource.getURL().toString();
+
+        logger.info("open url: {}", resourceUrl);
+
+        ConvertController controller = new ConvertController();
+
+        ConvertRequest request = ConvertRequest.builder().spec(IOUtils.toString(resource.getInputStream(),"UTF-8")).build();
+
+        //logger.info("request: {}",request);
+
+        ConvertResponse response = controller.convert(request);
+
+        logger.info("response: {}",response);
+
+        assertThat(response.getOpenApi().getInfo().getTitle(), is("Åpne Data fra Enhetsregisteret - API Dokumentasjon"));
+        assertThat(response.getOpenApi().getInfo().getContact().getName(), is("Forenkling og Brukerdialog hos Brønnøysundregistrene"));
+    }
+
+}

--- a/applications/api-cat/src/test/resources/logback-test.xml
+++ b/applications/api-cat/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework" level="ERROR"/>
+    <logger name="org.springframework.web" level="ERROR"/>
+
+	<logger name="no.dcat" level="DEBUG"/>
+    <logger name="no.acat" level="DEBUG"/>
+
+</configuration>

--- a/applications/api-cat/src/test/resources/raw-enhet-api.json
+++ b/applications/api-cat/src/test/resources/raw-enhet-api.json
@@ -1,0 +1,609 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://data.brreg.no/enhetsregisteret/api",
+      "description": "Produksjon"
+    }
+  ],
+  "info": {
+    "description": "Teknisk beskrivelse av REST-tjenestene i Åpne Data fra Enhetsregisteret - Work in progress\n---\n\n## Ordbok\n### Enhetsregisteret\nRegister over grunndata om juridiske personer og andre enheter. Enhetsregisteret tildeler organisasjonsnummer for entydig identifisering av enheter.\n\n### Organisasjonsnummer\nNisifret nummer som entydig identifiserer enheter i Enhetsregisteret.\n\n### Enhet\nEnhet på øverste nivå i registreringsstrukturen i Enhetsregisteret. Eksempelvis enkeltpersonforetak, foreninger, selskap, sameier og andre som er registrert i Enhetsregisteret. Identifiseres med organisasjonsnummer.\n\n### Underenhet\nEnhet på laveste nivå i registreringsstrukturen i Enhetsregisteret. En underenhet kan ikke eksistere alene og har alltid knytning til en hovedenhet. Identifiseres med organisasjonsnummer.\n\n### Organisasjonsform\nOrganisasjonsform er virksomhetens formelle organisering og gir retningslinjer overfor blant annet ansvarsforhold, skatt, revisjonsplikt, rettigheter og plikter.\n\n### Næringskode\n[Næringskoder]: https://www.brreg.no/bedrift/naeringskoder/\n[Næringskoder]  på brreg.no\n\n[Standard for næringsgruppering]: https://www.ssb.no/klass/klassifikasjoner/6\n[Standard for næringsgruppering]\n---\n\n## Versjonering\nDu kan velge major versjon ved å spesifisere HTTP Accept-headeren. Bruk headeren spesifisert i tabellen under. Hvis versjon ikke spesifiseres, vil man få siste versjon.\n<table>\n  <thead>\n    <tr>\n      <th>API</th>\n      <th>Header</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>/</td>\n      <td>application/vnd.enhetsregisteret.v1+json</td>\n    </tr>\n    <tr>\n      <td>/organisasjonsformer</td>\n      <td>application/vnd.enhetsregisteret.organisasjonsform.v1+json</td>\n    </tr>\n  </tbody>\n</table>\n\n\n### Strategi\nVi skal normalt ikke bryte bakoverkompabiliteten med våre brukere. Likevel kan det være nødvendig i enkelte situasjoner, av for eksempel juridiske årsaker eller vedlikehold, å gjøre endringer som medfører et slikt brudd. Vi vil i dette tilfellet versjonere tjenesten slik at nyeste versjon vil være tilgjengelig sammen med forrige versjon.\n\n#### Dersom man ikke benytter versjonering i accept header, vil man få siste versjon.\n\nEldre versjon vil anses som utdatert/deprecated, og vil på sikt bli tatt bort. Ved behov for denne typen endringer vil vi forsøke å gi bruker god tid, og varsle om endringen i forkant. Se punkt om varsling.\n\n### Når innføres ny versjon\nVi vil innføre en ny versjon når vi introduserer en endring som påvirker bakoverkompabiliteten. Mindre endringer og patcher vil ikke medføre versjonsendring i header.\n\n### Når fjernes en versjon\nVi vil legge ut varsel/driftsmeldinger i god tid på følgende steder:\n- [Driftsmeldinger]: https://www.brreg.no/om-oss/driftsmeldinger/\n[Driftsmeldinger]\n- [RSS-feed]: https://www.brreg.no/produkter-og-tjenester/rss-feed/\n[RSS-feed].\n\nEksempel på endring som medfører versjonering:\n\n- Fjerne eller endre navn på et attributt i HTTP-responsen.\n\n- Fjerne eller endre navn på et REST endepunkt.\n\n---\n\n## Endringslogg\n<table>\n  <thead>\n    <tr>\n      <th>Versjon</th>\n      <th>Dato</th>\n      <th>Endring</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>1.1.0</td>\n      <td>14. august 2018</td>\n      <td>Ny tjeneste /oppdateringer/enheter og /oppdateringer/underenheter</td>\n    </tr>\n    <tr>\n      <td>1.0.0</td>\n      <td>6. april 2018</td>\n      <td>Produksjonssetting av ny åpne data tjeneste for Enhetsregisteret</td>\n    </tr>\n  </tbody>\n</table>\n",
+    "version": "1.0.0",
+    "title": "Åpne Data fra Enhetsregisteret - API Dokumentasjon",
+    "contact": {
+      "name": "Forenkling og Brukerdialog hos Brønnøysundregistrene",
+      "email": "opendata@brreg.no"
+    },
+    "license": {
+      "name": "Norsk lisens for offentlige data (NLOD)",
+      "url": "https://data.norge.no/nlod/no/"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listTjenester",
+        "description": "Hent alle tjenester",
+        "responses": {
+          "200": {
+            "description": "Tjenester mot åpne data fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/enheter": {
+      "parameters": [
+        {
+          "name": "size",
+          "in": "query",
+          "description": "Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "page",
+          "in": "query",
+          "description": "Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "navn",
+          "in": "query",
+          "description": "Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sorter resultatsett på feltnavn. Merk at navn må sorteres på navn.norwegian",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "organisasjonsform",
+          "in": "query",
+          "description": "Filtrer på organisasjonsformkode. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "naeringskode",
+          "in": "query",
+          "description": "Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "kommunenummer",
+          "in": "query",
+          "description": "Filtrer på kommunenummer 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "overordnetEnhet",
+          "in": "query",
+          "description": "Organisasjonsnummeret til overordnet enhet",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fraRegistreringsdatoEnhetsregisteret",
+          "in": "query",
+          "description": "Filtrer på fra registreringsdato i Enhetsregisteret.",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilRegistreringsdatoEnhetsregisteret",
+          "in": "query",
+          "description": "Filtrer på til registreringsdato i Enhetsregisteret.",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "registrertIMvaregisteret",
+          "in": "query",
+          "description": "Filtrer på om enheten er registrert i Merverdiregisteret",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "konkurs",
+          "in": "query",
+          "description": "Filtrer på om enheten er registrert konkurs",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "fraAntallAnsatte",
+          "in": "query",
+          "description": "Filtrer på fra antall ansatte",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "tilAntallAnsatte",
+          "in": "query",
+          "description": "Filtrer på til antall ansatte",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "listEnheter",
+        "description": "Hent alle enheter",
+        "responses": {
+          "200": {
+            "description": "Enheter fra Enhetsregisteret"
+          },
+          "400": {
+            "description": "Ugyldig forespørsel"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/enheter/{organisasjonsnummer}": {
+      "parameters": [
+        {
+          "name": "organisasjonsnummer",
+          "in": "path",
+          "description": "Organisasjonsnummeret til enheten - 9 siffer",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "hentEnhet",
+        "description": "Hent detaljer om enhet",
+        "responses": {
+          "200": {
+            "description": "Enhet fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Enhet"
+                }
+              },
+              "application/vnd.enhetsregisteret.enhet.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Enhet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Enheten finnes ikke"
+          },
+          "410": {
+            "description": "Enheten er fjernet"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/underenheter": {
+      "parameters": [
+        {
+          "name": "size",
+          "in": "query",
+          "description": "Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "page",
+          "in": "query",
+          "description": "Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "navn",
+          "in": "query",
+          "description": "Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sorter resultatsett på feltnavn. Merk at navn må sorteres på navn.norwegian",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "organisasjonsform",
+          "in": "query",
+          "description": "Filtrer på organisasjonsformkode. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "naeringskode",
+          "in": "query",
+          "description": "Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "kommunenummer",
+          "in": "query",
+          "description": "Filtrer på kommunenummer 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "overordnetEnhet",
+          "in": "query",
+          "description": "Organisasjonsnummeret til overordnet enhet",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "listUnderenheter",
+        "description": "Hent alle underenheter",
+        "responses": {
+          "200": {
+            "description": "Underenheter fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/underenheter/{organisasjonsnummer}": {
+      "parameters": [
+        {
+          "name": "organisasjonsnummer",
+          "in": "path",
+          "description": "Organisasjonsnummeret til underenheten - 9 siffer",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "hentUnderenhet",
+        "description": "Hent detaljer om underenhet",
+        "responses": {
+          "200": {
+            "description": "Underenhet fra Enhetsregisteret"
+          },
+          "404": {
+            "description": "Underenhet finnes ikke"
+          },
+          "410": {
+            "description": "Underenhet er fjernet"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/oppdateringer/enheter": {
+      "get": {
+        "operationId": "listOppdateringerEnhet",
+        "description": "Hent oppdateringer på enheter",
+        "responses": {
+          "200": {
+            "description": "Oppdateringer på enheter fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/oppdateringer/underenheter": {
+      "get": {
+        "operationId": "listOppdateringerUnderenhet",
+        "description": "Hent oppdateringer på underenheter",
+        "responses": {
+          "200": {
+            "description": "Oppdateringer på underenheter fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/organisasjonsformer": {
+      "get": {
+        "operationId": "listOrganisasjonsformer",
+        "description": "Hent alle organisasjonsformer",
+        "responses": {
+          "200": {
+            "description": "Organisasjonsformer fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_Organisasjonsformer"
+                }
+              },
+              "application/vnd.enhetsregisteret.organisasjonsform.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_Organisasjonsformer"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/organisasjonsformer/{orgformKode}": {
+      "parameters": [
+        {
+          "name": "orgformKode",
+          "in": "path",
+          "description": "Kode for organisasjonsform",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "examples": {
+            "AS": {
+              "summary": "Organisasjonsformkode for Aksjeselskap",
+              "value": "AS"
+            }
+          }
+        }
+      ],
+      "get": {
+        "operationId": "hentOrganisasjonsform",
+        "description": "Hent en enkelt organisasjonsform fra kode",
+        "responses": {
+          "200": {
+            "description": "Organisasjonsform fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organisasjonsform"
+                }
+              },
+              "application/vnd.enhetsregisteret.organisasjonsform.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organisasjonsform"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organisasjonsformen eksisterer ikke"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Enhet": {
+        "properties": {
+          "organisasjonsnummer": {
+            "type": "string"
+          },
+          "navn": {
+            "type": "string"
+          },
+          "organisasjonsform": {
+            "$ref": "#/components/schemas/Organisasjonsform"
+          },
+          "postadresse": {
+            "$ref": "#/components/schemas/Adresse"
+          },
+          "registreringsdatoEnhetsregisteret": {
+            "type": "string"
+          },
+          "registrertIMvaregisteret": {
+            "type": "boolean"
+          },
+          "naeringskode1": {
+            "$ref": "#/components/schemas/Naeringskode"
+          },
+          "naeringskode2": {
+            "$ref": "#/components/schemas/Naeringskode"
+          },
+          "naeringskode3": {
+            "$ref": "#/components/schemas/Naeringskode"
+          },
+          "antallAnsatte": {
+            "type": "integer"
+          },
+          "forretningsadresse": {
+            "$ref": "#/components/schemas/Adresse"
+          },
+          "stiftelsedato": {
+            "type": "string"
+          },
+          "institusjonellSektorkode": {
+            "$ref": "#/components/schemas/Sektorkode"
+          },
+          "registrertIForetaksregisteret": {
+            "type": "boolean"
+          },
+          "registrertIStiftelsesregisteret": {
+            "type": "boolean"
+          },
+          "registrertIFrivillighetsregisteret": {
+            "type": "boolean"
+          },
+          "sisteInnsendteAarsregnskap": {
+            "type": "string"
+          },
+          "konkurs": {
+            "type": "boolean"
+          },
+          "underAvvikling": {
+            "type": "boolean"
+          },
+          "underTvangsavviklingEllerTvangsopplosning": {
+            "type": "boolean"
+          },
+          "maalform": {
+            "type": "string"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Self"
+          }
+        }
+      },
+      "Adresse": {
+        "properties": {
+          "land": {
+            "type": "string"
+          },
+          "landkode": {
+            "type": "string"
+          },
+          "postnummer": {
+            "type": "string"
+          },
+          "poststed": {
+            "type": "string"
+          },
+          "adresse": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "kommune": {
+            "type": "string"
+          },
+          "kommunenummer": {
+            "type": "string"
+          }
+        }
+      },
+      "Naeringskode": {
+        "properties": {
+          "kode": {
+            "type": "string"
+          },
+          "beskrivelse": {
+            "type": "string"
+          }
+        }
+      },
+      "Sektorkode": {
+        "properties": {
+          "kode": {
+            "type": "string"
+          },
+          "beskrivelse": {
+            "type": "string"
+          }
+        }
+      },
+      "_Organisasjonsformer": {
+        "properties": {
+          "embedded": {
+            "$ref": "#/components/schemas/Organisasjonsformer"
+          }
+        }
+      },
+      "Organisasjonsformer": {
+        "properties": {
+          "organisasjonsformer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Organisasjonsform"
+            }
+          }
+        }
+      },
+      "Organisasjonsform": {
+        "properties": {
+          "kode": {
+            "type": "string"
+          },
+          "beskrivelse": {
+            "type": "string"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Self"
+          }
+        }
+      },
+      "Self": {
+        "properties": {
+          "self": {
+            "$ref": "#/components/schemas/Href"
+          }
+        }
+      },
+      "Href": {
+        "properties": {
+          "href": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/applications/registration-api/src/main/java/no/dcat/controller/ApiRegistrationController.java
+++ b/applications/registration-api/src/main/java/no/dcat/controller/ApiRegistrationController.java
@@ -133,7 +133,7 @@ public class ApiRegistrationController {
         try {
             String apiSpecUrl = apiRegistrationData.getApiSpecUrl();
             String apiSpec = apiRegistrationData.getApiSpec();
-            OpenAPI openAPI = this.apiCatClient.convert(apiSpecUrl, apiSpec);
+            OpenAPI openAPI = apiCatClient.convert(apiSpecUrl, apiSpec);
             apiRegistrationData.setOpenApi(openAPI);
         } catch (Exception e) {
             throw new BadRequestException(e.getMessage());

--- a/applications/registration-api/src/test/java/no/dcat/controller/ApiRegistrationControllerTest.java
+++ b/applications/registration-api/src/test/java/no/dcat/controller/ApiRegistrationControllerTest.java
@@ -1,0 +1,97 @@
+package no.dcat.controller;
+
+import com.google.gson.Gson;
+import io.swagger.v3.oas.models.OpenAPI;
+import no.dcat.client.apicat.ApiCatClient;
+import no.dcat.factory.RegistrationFactory;
+import no.dcat.model.ApiRegistration;
+import no.dcat.model.Catalog;
+import no.dcat.service.ApiCatService;
+import no.dcat.service.ApiRegistrationRepository;
+import no.dcat.service.CatalogRepository;
+import no.dcat.shared.testcategories.UnitTest;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensaml.xml.parse.ClasspathResolver;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Category(UnitTest.class)
+@RunWith(SpringRunner.class)
+public class ApiRegistrationControllerTest {
+
+    private ApiRegistrationController apiRegistrationController;
+    private String catalogId = "1234";
+    private Resource apiResource;
+
+    @Mock
+    private CatalogRepository catalogRepository;
+
+    @Mock
+    private ApiRegistrationRepository apiRegistrationRepository;
+
+    @Mock
+    private ApiCatService apiCatService;
+
+    @Mock
+    private ApiCatClient apiCatClient;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+
+        Catalog catalog = new Catalog();
+        catalog.setId(catalogId);
+        apiResource = new ClassPathResource("raw-enhet-api.json");
+        OpenAPI openApi = new Gson().fromJson(IOUtils.toString(apiResource.getInputStream(), "UTF-8"), OpenAPI.class);
+        ApiRegistration apiRegistrationData;
+
+        when(catalogRepository.findById(anyString())).thenReturn(Optional.of(catalog));
+        when(apiCatService.getClient()).thenReturn(apiCatClient);
+        when(apiCatClient.convert(apiResource.getURL().toString(), null)).thenReturn(openApi);
+
+        ApiRegistration apiRegData = mock(ApiRegistration.class);
+        when(apiRegData.getId()).thenReturn("id");
+        when(apiRegistrationRepository.save(anyObject())).thenReturn(apiRegData);
+        //doNothing().when(apiCatClient).triggerHarvestApiRegistration(anyString());
+
+        apiRegistrationController = new ApiRegistrationController(apiRegistrationRepository, catalogRepository, apiCatService);
+
+
+    }
+
+    @Test
+    public void createApiRegistrationOK() throws Throwable {
+
+        ApiRegistration apiRegData = new ApiRegistration();
+        apiRegData.setApiSpecUrl(apiResource.getURL().toString());
+
+        ApiRegistration actual = apiRegistrationController.createApiRegistration(catalogId, apiRegData);
+
+        ArgumentCaptor<ApiRegistration> apiCaptor = ArgumentCaptor.forClass(ApiRegistration.class);
+        verify(apiRegistrationRepository).save(apiCaptor.capture());
+
+        actual = apiCaptor.getValue();
+        assertThat(actual.getOpenApi().getInfo().getTitle(), is("Åpne Data fra Enhetsregisteret - API Dokumentasjon"));
+    }
+
+}

--- a/applications/registration-api/src/test/resources/raw-enhet-api.json
+++ b/applications/registration-api/src/test/resources/raw-enhet-api.json
@@ -1,0 +1,609 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://data.brreg.no/enhetsregisteret/api",
+      "description": "Produksjon"
+    }
+  ],
+  "info": {
+    "description": "Teknisk beskrivelse av REST-tjenestene i Åpne Data fra Enhetsregisteret - Work in progress\n---\n\n## Ordbok\n### Enhetsregisteret\nRegister over grunndata om juridiske personer og andre enheter. Enhetsregisteret tildeler organisasjonsnummer for entydig identifisering av enheter.\n\n### Organisasjonsnummer\nNisifret nummer som entydig identifiserer enheter i Enhetsregisteret.\n\n### Enhet\nEnhet på øverste nivå i registreringsstrukturen i Enhetsregisteret. Eksempelvis enkeltpersonforetak, foreninger, selskap, sameier og andre som er registrert i Enhetsregisteret. Identifiseres med organisasjonsnummer.\n\n### Underenhet\nEnhet på laveste nivå i registreringsstrukturen i Enhetsregisteret. En underenhet kan ikke eksistere alene og har alltid knytning til en hovedenhet. Identifiseres med organisasjonsnummer.\n\n### Organisasjonsform\nOrganisasjonsform er virksomhetens formelle organisering og gir retningslinjer overfor blant annet ansvarsforhold, skatt, revisjonsplikt, rettigheter og plikter.\n\n### Næringskode\n[Næringskoder]: https://www.brreg.no/bedrift/naeringskoder/\n[Næringskoder]  på brreg.no\n\n[Standard for næringsgruppering]: https://www.ssb.no/klass/klassifikasjoner/6\n[Standard for næringsgruppering]\n---\n\n## Versjonering\nDu kan velge major versjon ved å spesifisere HTTP Accept-headeren. Bruk headeren spesifisert i tabellen under. Hvis versjon ikke spesifiseres, vil man få siste versjon.\n<table>\n  <thead>\n    <tr>\n      <th>API</th>\n      <th>Header</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>/</td>\n      <td>application/vnd.enhetsregisteret.v1+json</td>\n    </tr>\n    <tr>\n      <td>/organisasjonsformer</td>\n      <td>application/vnd.enhetsregisteret.organisasjonsform.v1+json</td>\n    </tr>\n  </tbody>\n</table>\n\n\n### Strategi\nVi skal normalt ikke bryte bakoverkompabiliteten med våre brukere. Likevel kan det være nødvendig i enkelte situasjoner, av for eksempel juridiske årsaker eller vedlikehold, å gjøre endringer som medfører et slikt brudd. Vi vil i dette tilfellet versjonere tjenesten slik at nyeste versjon vil være tilgjengelig sammen med forrige versjon.\n\n#### Dersom man ikke benytter versjonering i accept header, vil man få siste versjon.\n\nEldre versjon vil anses som utdatert/deprecated, og vil på sikt bli tatt bort. Ved behov for denne typen endringer vil vi forsøke å gi bruker god tid, og varsle om endringen i forkant. Se punkt om varsling.\n\n### Når innføres ny versjon\nVi vil innføre en ny versjon når vi introduserer en endring som påvirker bakoverkompabiliteten. Mindre endringer og patcher vil ikke medføre versjonsendring i header.\n\n### Når fjernes en versjon\nVi vil legge ut varsel/driftsmeldinger i god tid på følgende steder:\n- [Driftsmeldinger]: https://www.brreg.no/om-oss/driftsmeldinger/\n[Driftsmeldinger]\n- [RSS-feed]: https://www.brreg.no/produkter-og-tjenester/rss-feed/\n[RSS-feed].\n\nEksempel på endring som medfører versjonering:\n\n- Fjerne eller endre navn på et attributt i HTTP-responsen.\n\n- Fjerne eller endre navn på et REST endepunkt.\n\n---\n\n## Endringslogg\n<table>\n  <thead>\n    <tr>\n      <th>Versjon</th>\n      <th>Dato</th>\n      <th>Endring</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>1.1.0</td>\n      <td>14. august 2018</td>\n      <td>Ny tjeneste /oppdateringer/enheter og /oppdateringer/underenheter</td>\n    </tr>\n    <tr>\n      <td>1.0.0</td>\n      <td>6. april 2018</td>\n      <td>Produksjonssetting av ny åpne data tjeneste for Enhetsregisteret</td>\n    </tr>\n  </tbody>\n</table>\n",
+    "version": "1.0.0",
+    "title": "Åpne Data fra Enhetsregisteret - API Dokumentasjon",
+    "contact": {
+      "name": "Forenkling og Brukerdialog hos Brønnøysundregistrene",
+      "email": "opendata@brreg.no"
+    },
+    "license": {
+      "name": "Norsk lisens for offentlige data (NLOD)",
+      "url": "https://data.norge.no/nlod/no/"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listTjenester",
+        "description": "Hent alle tjenester",
+        "responses": {
+          "200": {
+            "description": "Tjenester mot åpne data fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/enheter": {
+      "parameters": [
+        {
+          "name": "size",
+          "in": "query",
+          "description": "Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "page",
+          "in": "query",
+          "description": "Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "navn",
+          "in": "query",
+          "description": "Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sorter resultatsett på feltnavn. Merk at navn må sorteres på navn.norwegian",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "organisasjonsform",
+          "in": "query",
+          "description": "Filtrer på organisasjonsformkode. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "naeringskode",
+          "in": "query",
+          "description": "Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "kommunenummer",
+          "in": "query",
+          "description": "Filtrer på kommunenummer 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "overordnetEnhet",
+          "in": "query",
+          "description": "Organisasjonsnummeret til overordnet enhet",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fraRegistreringsdatoEnhetsregisteret",
+          "in": "query",
+          "description": "Filtrer på fra registreringsdato i Enhetsregisteret.",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilRegistreringsdatoEnhetsregisteret",
+          "in": "query",
+          "description": "Filtrer på til registreringsdato i Enhetsregisteret.",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "registrertIMvaregisteret",
+          "in": "query",
+          "description": "Filtrer på om enheten er registrert i Merverdiregisteret",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "konkurs",
+          "in": "query",
+          "description": "Filtrer på om enheten er registrert konkurs",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "fraAntallAnsatte",
+          "in": "query",
+          "description": "Filtrer på fra antall ansatte",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "tilAntallAnsatte",
+          "in": "query",
+          "description": "Filtrer på til antall ansatte",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "listEnheter",
+        "description": "Hent alle enheter",
+        "responses": {
+          "200": {
+            "description": "Enheter fra Enhetsregisteret"
+          },
+          "400": {
+            "description": "Ugyldig forespørsel"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/enheter/{organisasjonsnummer}": {
+      "parameters": [
+        {
+          "name": "organisasjonsnummer",
+          "in": "path",
+          "description": "Organisasjonsnummeret til enheten - 9 siffer",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "hentEnhet",
+        "description": "Hent detaljer om enhet",
+        "responses": {
+          "200": {
+            "description": "Enhet fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Enhet"
+                }
+              },
+              "application/vnd.enhetsregisteret.enhet.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Enhet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Enheten finnes ikke"
+          },
+          "410": {
+            "description": "Enheten er fjernet"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/underenheter": {
+      "parameters": [
+        {
+          "name": "size",
+          "in": "query",
+          "description": "Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "page",
+          "in": "query",
+          "description": "Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "navn",
+          "in": "query",
+          "description": "Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sorter resultatsett på feltnavn. Merk at navn må sorteres på navn.norwegian",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "organisasjonsform",
+          "in": "query",
+          "description": "Filtrer på organisasjonsformkode. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "naeringskode",
+          "in": "query",
+          "description": "Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "kommunenummer",
+          "in": "query",
+          "description": "Filtrer på kommunenummer 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "overordnetEnhet",
+          "in": "query",
+          "description": "Organisasjonsnummeret til overordnet enhet",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "listUnderenheter",
+        "description": "Hent alle underenheter",
+        "responses": {
+          "200": {
+            "description": "Underenheter fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/underenheter/{organisasjonsnummer}": {
+      "parameters": [
+        {
+          "name": "organisasjonsnummer",
+          "in": "path",
+          "description": "Organisasjonsnummeret til underenheten - 9 siffer",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "hentUnderenhet",
+        "description": "Hent detaljer om underenhet",
+        "responses": {
+          "200": {
+            "description": "Underenhet fra Enhetsregisteret"
+          },
+          "404": {
+            "description": "Underenhet finnes ikke"
+          },
+          "410": {
+            "description": "Underenhet er fjernet"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/oppdateringer/enheter": {
+      "get": {
+        "operationId": "listOppdateringerEnhet",
+        "description": "Hent oppdateringer på enheter",
+        "responses": {
+          "200": {
+            "description": "Oppdateringer på enheter fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/oppdateringer/underenheter": {
+      "get": {
+        "operationId": "listOppdateringerUnderenhet",
+        "description": "Hent oppdateringer på underenheter",
+        "responses": {
+          "200": {
+            "description": "Oppdateringer på underenheter fra Enhetsregisteret"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/organisasjonsformer": {
+      "get": {
+        "operationId": "listOrganisasjonsformer",
+        "description": "Hent alle organisasjonsformer",
+        "responses": {
+          "200": {
+            "description": "Organisasjonsformer fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_Organisasjonsformer"
+                }
+              },
+              "application/vnd.enhetsregisteret.organisasjonsform.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_Organisasjonsformer"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/organisasjonsformer/{orgformKode}": {
+      "parameters": [
+        {
+          "name": "orgformKode",
+          "in": "path",
+          "description": "Kode for organisasjonsform",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "examples": {
+            "AS": {
+              "summary": "Organisasjonsformkode for Aksjeselskap",
+              "value": "AS"
+            }
+          }
+        }
+      ],
+      "get": {
+        "operationId": "hentOrganisasjonsform",
+        "description": "Hent en enkelt organisasjonsform fra kode",
+        "responses": {
+          "200": {
+            "description": "Organisasjonsform fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organisasjonsform"
+                }
+              },
+              "application/vnd.enhetsregisteret.organisasjonsform.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organisasjonsform"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organisasjonsformen eksisterer ikke"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Enhet": {
+        "properties": {
+          "organisasjonsnummer": {
+            "type": "string"
+          },
+          "navn": {
+            "type": "string"
+          },
+          "organisasjonsform": {
+            "$ref": "#/components/schemas/Organisasjonsform"
+          },
+          "postadresse": {
+            "$ref": "#/components/schemas/Adresse"
+          },
+          "registreringsdatoEnhetsregisteret": {
+            "type": "string"
+          },
+          "registrertIMvaregisteret": {
+            "type": "boolean"
+          },
+          "naeringskode1": {
+            "$ref": "#/components/schemas/Naeringskode"
+          },
+          "naeringskode2": {
+            "$ref": "#/components/schemas/Naeringskode"
+          },
+          "naeringskode3": {
+            "$ref": "#/components/schemas/Naeringskode"
+          },
+          "antallAnsatte": {
+            "type": "integer"
+          },
+          "forretningsadresse": {
+            "$ref": "#/components/schemas/Adresse"
+          },
+          "stiftelsedato": {
+            "type": "string"
+          },
+          "institusjonellSektorkode": {
+            "$ref": "#/components/schemas/Sektorkode"
+          },
+          "registrertIForetaksregisteret": {
+            "type": "boolean"
+          },
+          "registrertIStiftelsesregisteret": {
+            "type": "boolean"
+          },
+          "registrertIFrivillighetsregisteret": {
+            "type": "boolean"
+          },
+          "sisteInnsendteAarsregnskap": {
+            "type": "string"
+          },
+          "konkurs": {
+            "type": "boolean"
+          },
+          "underAvvikling": {
+            "type": "boolean"
+          },
+          "underTvangsavviklingEllerTvangsopplosning": {
+            "type": "boolean"
+          },
+          "maalform": {
+            "type": "string"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Self"
+          }
+        }
+      },
+      "Adresse": {
+        "properties": {
+          "land": {
+            "type": "string"
+          },
+          "landkode": {
+            "type": "string"
+          },
+          "postnummer": {
+            "type": "string"
+          },
+          "poststed": {
+            "type": "string"
+          },
+          "adresse": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "kommune": {
+            "type": "string"
+          },
+          "kommunenummer": {
+            "type": "string"
+          }
+        }
+      },
+      "Naeringskode": {
+        "properties": {
+          "kode": {
+            "type": "string"
+          },
+          "beskrivelse": {
+            "type": "string"
+          }
+        }
+      },
+      "Sektorkode": {
+        "properties": {
+          "kode": {
+            "type": "string"
+          },
+          "beskrivelse": {
+            "type": "string"
+          }
+        }
+      },
+      "_Organisasjonsformer": {
+        "properties": {
+          "embedded": {
+            "$ref": "#/components/schemas/Organisasjonsformer"
+          }
+        }
+      },
+      "Organisasjonsformer": {
+        "properties": {
+          "organisasjonsformer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Organisasjonsform"
+            }
+          }
+        }
+      },
+      "Organisasjonsform": {
+        "properties": {
+          "kode": {
+            "type": "string"
+          },
+          "beskrivelse": {
+            "type": "string"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Self"
+          }
+        }
+      },
+      "Self": {
+        "properties": {
+          "self": {
+            "$ref": "#/components/schemas/Href"
+          }
+        }
+      },
+      "Href": {
+        "properties": {
+          "href": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Jeg la til -Dfile.encoding=UTF-8 i pommen, slik at vi tvinger testene til å kjøre default encoding = UTF-8. Før dette var de Windows-1252  /CP-1252 på min maskin, og forårsaket at Parseren døde stille på øæå. La også til mer feilhåndtering slik at dette blir meldt fra om vi møter på noe lignende igjen.