### PR TITLE
NOT-MVP (api-cat) Configure application log level with environment variable

### DIFF
--- a/applications/api-cat/src/main/resources/application.yml
+++ b/applications/api-cat/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring.jackson.default-property-inclusion: non_null
 logging:
-  level.: WARN
-  level.no.acat: INFO
+  level: WARN
+  level.no.acat: ${LOG_LEVEL:INFO}
   level.org.springframework: WARN
   level.org.springframework.web: WARN
 application:

--- a/applications/api-cat/src/main/resources/banner.txt
+++ b/applications/api-cat/src/main/resources/banner.txt
@@ -1,0 +1,7 @@
+               _                      _
+  __ _  _ __  (_)         ___   __ _ | |_
+ / _` || '_ \ | | _____  / __| / _` || __|
+| (_| || |_) || ||_____|| (__ | (_| || |_
+ \__,_|| .__/ |_|        \___| \__,_| \__|
+       |_|
+${application.formatted-version}, Spring Boot ${spring-boot.formatted-version}, Log level ${logging.level.no.acat}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,6 +22,7 @@ services:
       - JAVA_OPTS= -ea -Djava.security.egd=file:/dev/./urandom -Xmx256M -Dspring.profiles.active=docker
       - FDK_ES_CLUSTERNODES=elasticsearch5:9300
       - FDK_ES_CLUSTERNAME=elasticsearch
+      - LOG_LEVEL=${LOG_LEVEL}
 
   search-api:
     restart: always


### PR DESCRIPTION
Dokumentasjon sier, at miljøvariabler har høyere prioritet enn application.yml, men det virker ikke... kan det være på grunn av punkter i variable?
https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html

Det skjer noe magi i openshift, vi setter - logging_level_no_acat:DEBUG og det virker.

I docker-comose virker det ikke.
