### PR TITLE
Revert "Use travis_wait to set build timeout to 30. This causes build…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
   include:
     - stage: Build
       if: type = pull_request OR ( type = push AND branch = develop )
-      script: travis_wait 30 source ./travisBuild.sh
+      script: source ./travisBuild.sh
       env:
         - comment=Build all applications
 


### PR DESCRIPTION
Jeg glemte halvparten av grunn hvorfor vi kan ikke merge den timeout.

I tillegg til ikke vise log løpende, travis også mister siste (viktigste) biten av log på grunn av skript er drept før log er ferdigsamlet.

Så, det er faktisk vanskelig å si, hvilken måte er den best :D