### PR TITLE
(registration-api) added property for prd environment keystore password

### DIFF
--- a/applications/registration-api/src/main/resources/application.yml
+++ b/applications/registration-api/src/main/resources/application.yml
@@ -49,6 +49,7 @@ saml:
         difi.brreg.datakatalog.registrering.it1: ${registrationApi_ipKeyPassword}
         difi.brreg.datakatalog.registrering.st1: ${registrationApi_ipKeyPassword}
         difi.brreg.datakatalog.registrering.ppe: ${registrationApi_ipKeyPassword}
+        difi.brreg.datakatalog.registrering.prd: ${registrationApi_ipKeyPassword}
         difi.brreg.datakatalog.registrering.tt1: ${registrationApi_ipKeyPassword}
         difi.brreg.datakatalog.registrering.ut1: ${registrationApi_ipKeyPassword}
         difi.brreg.datakatalog.registrering.st2: ${registrationApi_ipKeyPassword}


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-543
Må vel ha tilsvarende variabel for prd også, siden produksjonsmiljøet på GCP vil hete prd (og ikke ppe som i dag)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
