### PR TITLE
(search) update publisher-label component with tag prop

### DIFF
--- a/applications/search/src/components/publisher-label/__snapshots__/publisher-label.component.test.jsx.snap
+++ b/applications/search/src/components/publisher-label/__snapshots__/publisher-label.component.test.jsx.snap
@@ -4,11 +4,9 @@ exports[`should render PublisherLabel with no prefLabel 1`] = `
 <span>
   Eies av
    
-  <span
-    className="fdk-strong-virksomhet"
-  >
+  <strong>
     Ramsund og rognan revisjon
-  </span>
+  </strong>
 </span>
 `;
 
@@ -18,10 +16,8 @@ exports[`should render PublisherLabel with publisher 1`] = `
 <span>
   Eies av
    
-  <span
-    className="fdk-strong-virksomhet"
-  >
+  <strong>
     Ramsund og Rognan revisjon
-  </span>
+  </strong>
 </span>
 `;

--- a/applications/search/src/components/publisher-label/publisher-label.component.jsx
+++ b/applications/search/src/components/publisher-label/publisher-label.component.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { getTranslateText } from '../../lib/translateText';
 
 export const PublisherLabel = props => {
-  const { label, publisherItem } = props;
+  const { label, tag: Tag, publisherItem } = props;
   if (!publisherItem) {
     return null;
   }
@@ -16,17 +16,19 @@ export const PublisherLabel = props => {
   return (
     <span>
       {label}&nbsp;
-      <span className="fdk-strong-virksomhet">{publisherPrefLabel}</span>
+      <Tag>{publisherPrefLabel}</Tag>
     </span>
   );
 };
 
 PublisherLabel.defaultProps = {
   label: null,
+  tag: 'strong',
   publisherItem: null
 };
 
 PublisherLabel.propTypes = {
   label: PropTypes.string,
+  tag: PropTypes.string,
   publisherItem: PropTypes.object
 };

--- a/applications/search/src/components/search-hit-header/__snapshots__/search-hit-header.component.test.jsx.snap
+++ b/applications/search/src/components/search-hit-header/__snapshots__/search-hit-header.component.test.jsx.snap
@@ -44,6 +44,7 @@ exports[`should render SearchHitHeader with harvest dates 1`] = `
           "valid": true,
         }
       }
+      tag="strong"
     />
   </div>
   <div

--- a/applications/search/src/pages/search-page/results-concepts/concepts-hit-item/__snapshots__/concepts-hit-item.test.jsx.snap
+++ b/applications/search/src/pages/search-page/results-concepts/concepts-hit-item/__snapshots__/concepts-hit-item.test.jsx.snap
@@ -78,6 +78,7 @@ exports[`should render ConceptsHitItem correctly 1`] = `
           "valid": true,
         }
       }
+      tag="strong"
     />
     <div
       className="mt-3"
@@ -207,6 +208,7 @@ exports[`should render ConceptsHitItem correctly with compare button not showing
           "valid": true,
         }
       }
+      tag="strong"
     />
     <div
       className="mt-3"


### PR DESCRIPTION
(cherry picked from commit 10154ec)

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
Kunne angi hvilken type tag man vil vise publisher name i fra der man bruker komponenten, f.eks. angi strong eller span