### PR TITLE
(search) Protect from concept item loading, when compare list is empty

### DIFF
--- a/applications/search/src/redux/modules/conceptsCompare.js
+++ b/applications/search/src/redux/modules/conceptsCompare.js
@@ -19,7 +19,7 @@ function shouldFetch(metaState) {
 
 export function fetchConceptsToCompareIfNeededAction(iDs) {
   return (dispatch, getState) => {
-    iDs.forEach(id => {
+    iDs.filter(id => !!id).forEach(id => {
       if (shouldFetch(_.get(getState(), ['conceptsCompare', 'meta', id]))) {
         dispatch(
           fetchActions(`/api/concepts/${id}`, [


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
