### PR TITLE
ON HOLD: Added mapping for the two of three fields that we want to directly ac…

### DIFF
--- a/applications/registration-api/src/main/java/no/dcat/model/ApiHarvestStatus.java
+++ b/applications/registration-api/src/main/java/no/dcat/model/ApiHarvestStatus.java
@@ -1,0 +1,9 @@
+package no.dcat.model;
+
+import lombok.*;
+
+@Data
+public class ApiHarvestStatus {
+    public boolean success;
+    public String errorMessage;
+}

--- a/applications/registration-api/src/main/java/no/dcat/model/ApiRegistration.java
+++ b/applications/registration-api/src/main/java/no/dcat/model/ApiRegistration.java
@@ -33,7 +33,7 @@ public class ApiRegistration extends ApiRegistrationPublic {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
     private Date _lastModified;
 
-    private HarvestMetadata harvestMetadata;
+    private HarvestMetadata harvest;
 
     private ApiHarvestStatus harvestStatus;
 

--- a/applications/registration-api/src/main/java/no/dcat/model/ApiRegistration.java
+++ b/applications/registration-api/src/main/java/no/dcat/model/ApiRegistration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import no.dcat.client.registrationapi.ApiRegistrationPublic;
+import no.dcat.shared.HarvestMetadata;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 
@@ -31,4 +32,12 @@ public class ApiRegistration extends ApiRegistrationPublic {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
     private Date _lastModified;
+
+    private HarvestMetadata harvestMetadata;
+
+    private ApiHarvestStatus harvestStatus;
+
+    private boolean isFromApiCatalog;
+
+
 }

--- a/applications/registration-api/src/main/resources/api-mappings.json
+++ b/applications/registration-api/src/main/resources/api-mappings.json
@@ -7,6 +7,19 @@
       },
       "registrationStatus": {
         "type": "keyword"
+      },
+      "isFromApiCatalog": {
+        "type": "boolean"
+      },
+      "harveststatus": {
+        "properties": {
+          "success": {
+            "type":"boolean"
+          },
+          "errorMessage": {
+            "type" : "text"
+          }
+        }
       }
     }
   }

--- a/applications/registration-api/src/test/java/no/dcat/model/ApiRegistrationTest.java
+++ b/applications/registration-api/src/test/java/no/dcat/model/ApiRegistrationTest.java
@@ -1,0 +1,25 @@
+package no.dcat.model;
+
+import no.dcat.shared.testcategories.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+@Category(UnitTest.class)
+public class ApiRegistrationTest {
+
+
+    @Test
+    public void harvestStatusIsStored() {
+        ApiRegistration registration = new ApiRegistration();
+
+        ApiHarvestStatus status = new ApiHarvestStatus();
+        status.success = true;
+        registration.setHarvestStatus(status);
+
+        assertThat(status, is(registration.getHarvestStatus()));
+    }
+}


### PR DESCRIPTION
…cess

https://jira.brreg.no/browse/API-607

Feltene som er nødvendig er nå lagt inn. 

Manuelt testet med slett av lokalt index reg-api og restart og ser ved visuell inspeksjon at mappingen er i index.

Etter diskusjon så dras også følgende inn:
https://jira.brreg.no/browse/API-609 (filtrere på status i endepunkt)

Denne oppgaven utvides også til å inneholde endringer på domeneobjekt:  no.dcat.model.ApiRegistration (som er mappet til index reg-api) 



