### PR TITLE
Use snapshot versions for applications. Keep semantic versions for libraries

### DIFF
--- a/applications/api-cat/pom.xml
+++ b/applications/api-cat/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>api-cat</artifactId>
-    <version>0.2.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/applications/concept-cat/pom.xml
+++ b/applications/concept-cat/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>concept-cat</artifactId>
-    <version>0.1.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/applications/dev-management/pom.xml
+++ b/applications/dev-management/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>dev-management</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <description>Development Management Tools</description>
     <packaging>jar</packaging>
 

--- a/applications/end2end-test/pom.xml
+++ b/applications/end2end-test/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>end2end-test</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <properties>
         <!--standard properties-->

--- a/applications/fuseki/pom.xml
+++ b/applications/fuseki/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>fuseki</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <properties>
         <docker.image.prefix>dcatno</docker.image.prefix>

--- a/applications/harvester-api/pom.xml
+++ b/applications/harvester-api/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>harvester-api</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/applications/harvester/pom.xml
+++ b/applications/harvester/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>no.dcat</groupId>
 	<artifactId>harvester</artifactId>
-	<version>1.0.1</version>
+    <version>2.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/applications/reference-data/pom.xml
+++ b/applications/reference-data/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>reference-data</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/applications/registration-api/pom.xml
+++ b/applications/registration-api/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>registration-api</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/applications/registration-auth/pom.xml
+++ b/applications/registration-auth/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>registration-auth</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/applications/search-api/pom.xml
+++ b/applications/search-api/pom.xml
@@ -5,7 +5,7 @@
     <groupId>no.dcat</groupId>
     <artifactId>search-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.2</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Det er grunn hvorfor libraries må ha semantisk versionering - det er at endringsdeteksjonsmekanism skulle trigger rekompilering av aplikasjonmoduler. 
Men top-applikasjoner må alltid rekompileres, derfor har de snapshot markering.