### PR TITLE
Expose management apis on the same port as main apis.

### DIFF
--- a/applications/api-cat/src/main/resources/application.yml
+++ b/applications/api-cat/src/main/resources/application.yml
@@ -12,11 +12,6 @@ application:
 elastic:
   clusterNodes: ${FDK_ES_CLUSTERNODES:elasticsearch5:9300}
   clusterName: ${FDK_ES_CLUSTERNAME:elasticsearch}
-server:
-  port: 8080
-management:
-  server:
-    port: 8181
 
 ---
 #Utv-miljø lokalt på egen PC
@@ -29,6 +24,3 @@ elastic:
   clusterName: elasticsearch
 server:
   port: 8088
-management:
-  server:
-    port: 8997

--- a/applications/concept-cat/src/main/resources/application.yml
+++ b/applications/concept-cat/src/main/resources/application.yml
@@ -16,11 +16,6 @@ application:
   apiRootUrl: http://nginx-search:8080/api
   apiRootExternalURL: https://fellesdatakatalog.brreg.no/api
   conceptsPath: /concepts
-server:
-  port: 8080
-management:
-  server:
-    port: 8181
 
 ---
 #Utv-miljø lokalt på egen PC
@@ -36,6 +31,3 @@ application:
   conceptsPath: /concepts
 server:
   port: 8088
-management:
-  server:
-    port: 8997

--- a/applications/dev-management/src/main/resources/application.yml
+++ b/applications/dev-management/src/main/resources/application.yml
@@ -4,10 +4,6 @@ logging:
   level.no.difi: ERROR
   level.no.dcat: INFO
   level.org.springframework: ERROR
-server:
-  port: 8080
-management:
-  port: 8181
 application:
   elasticsearchHost: elasticsearch
   elasticsearchPort: 9300
@@ -33,5 +29,3 @@ application:
   harvesterHost: http://localhost:8081
 server:
   port: 8074
-management:
-  port: 8994

--- a/applications/harvester-api/src/main/resources/application.yml
+++ b/applications/harvester-api/src/main/resources/application.yml
@@ -6,11 +6,6 @@ logging:
   level.org.springframework: ERROR
   level.org.springframework.web: ERROR
   level.org.elasticsearch: WARN
-server:
-  port: 8080
-management:
-  server:
-    port: 8181
 application:
   httpUsername: ${themesHttpUsername:user}
   httpPassword: ${themesHttpPassword:password}
@@ -64,9 +59,6 @@ elastic:
   clusterName: elasticsearch
 server:
   port: 8081
-management:
-  server:
-    port: 8991
 
 ---
 spring:

--- a/applications/harvester/src/main/resources/application.yml
+++ b/applications/harvester/src/main/resources/application.yml
@@ -8,11 +8,6 @@ logging:
 spring:
   mvc.view.prefix: /WEB-INF/jsp/
   mvc.view.suffix: .jsp
-server:
-  port: 8080
-management:
-  server:
-    port: 8181
 fuseki:
   dcatServiceUri: ${fusekiDcatServiceUri:http://fuseki:8080/fuseki/dcat}
   adminServiceUri: ${fusekiAdminServiceUri:http://fuseki:8080/fuseki/admin}
@@ -31,6 +26,3 @@ application:
   harvesterUrl: http://localhost:8081
 server:
   port: 8082
-management:
-  server:
-    port: 8992

--- a/applications/reference-data/src/main/resources/application.yml
+++ b/applications/reference-data/src/main/resources/application.yml
@@ -21,8 +21,5 @@ spring:
   profiles: develop
 server:
   port: 8100
-management:
-  server:
-    port: 8101
 
 

--- a/applications/registration-api/src/main/resources/application.yml
+++ b/applications/registration-api/src/main/resources/application.yml
@@ -22,13 +22,6 @@ application:
   harvesterUrl: http://harvester:8080
   openDataEnhet: ${FDK_ENHETSREGISTERET_URL:https://data.brreg.no/enhetsregisteret/api/enheter/}
 
-management:
-  server:
-    port: 8081
-  endpoints:
-      enabled-by-default: true
-      web.exposure.include: "*"
-
 spring:
   jackson:
     default-property-inclusion: non_null

--- a/applications/registration-auth/src/main/resources/application.yml
+++ b/applications/registration-auth/src/main/resources/application.yml
@@ -4,11 +4,6 @@ logging:
   level.no.difi: ERROR
   level.no.dcat: INFO
   level.org.springframework: ERROR
-server:
-  port: 8080
-management:
-  server:
-    port: 8181
 
 ---
 spring:

--- a/applications/search-api/src/main/resources/application.yml
+++ b/applications/search-api/src/main/resources/application.yml
@@ -6,11 +6,6 @@ application:
 elastic:
   clusterNodes: ${FDK_ES_CLUSTERNODES:elasticsearch5:9300}
   clusterName: ${FDK_ES_CLUSTERNAME:elasticsearch}
-server:
-  port: 8080
-management:
-  server:
-    port: 8181
 
 ---
 #Utv-miljø lokalt på egen PC
@@ -25,6 +20,3 @@ logging:
   level.no.dcat: INFO
 server:
   port: 8093
-management:
-  server:
-    port: 8993

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,6 @@ services:
     restart: always
     ports:
     - "8087:8080"
-    - "9087:8181"
     environment:
     - JAVA_OPTS= -ea -Djava.security.egd=file:/dev/./urandom -Xmx256M -Dspring.profiles.active=docker
     - FDK_ES_CLUSTERNODES=elasticsearch5:9300
@@ -36,7 +35,6 @@ services:
     restart: always
     ports:
     - "8083:8080"
-    - "9083:8181"
     environment:
     - JAVA_OPTS= -ea -Djava.security.egd=file:/dev/./urandom -Xmx256M -Dspring.profiles.active=docker
     - FDK_ES_CLUSTERNODES=elasticsearch5:9300
@@ -58,7 +56,6 @@ services:
     restart: always
     ports:
     - "8081:8080"
-    - "9081:8181"
     environment:
     - JAVA_OPTS= -ea -Djava.security.egd=file:/dev/./urandom -Xmx1024M -Dspring.profiles.active=docker
     - FDK_ES_CLUSTERNODES=elasticsearch5:9300
@@ -110,7 +107,6 @@ services:
     restart: always
     ports:
     - "8079:8080"
-    - "9079:8081"
     environment:
     - JAVA_OPTS= -ea -Djava.security.egd=file:/dev/./urandom -Xmx256M -Dspring.profiles.active=docker
     - FDK_ES_CLUSTERNODES=elasticsearch5:9300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     image: dcatno/api-cat:latest
     expose:
     - "8080"
-    - "8181"
     depends_on:
     - elasticsearch5
     - reference-data


### PR DESCRIPTION
Load balancer eksponerer public url som
fdk.no/api/concepts/*
fdk.no/metrics/concepts/liveness

Dette PR handler om hva skjer i interne kubernetes (eller docker-compose) nettverk.
Vi kan tenke om to løsning:
1) load balancer eksponer ikke root men bare spesifikk path
Det mener at vi må definere (maintain) flere regler i nginx. Det er ikke så mye vi vet om:
- concepts-api:8080/concepts* ---> fdk.no/api/concepts*
- concepts-api:8081/actuator/health ---> fdk.no/metrics/concepts/liveness
- trigger endepunkt til å sende meldinger. det er ikke bestemt nå. I api module vi trenger bare internt trigger

2) hvis tjeneste kunne eksponere flere porter, da kan vi potensielt eksponere root path via LB (nginx). Vi har ikke brukt dette ennå. Vi kunne teoretisk unngå definere path  prefix (concepts som eksempel) i app, men jeg ser ikke noe verdi i dette:
- concepts-api:8080/* ---> fdk.no/api/concepts*

Skulle vi bruke samme port eller forskjellige port til management?
Før dette pr vi brukte to forskjellige porter 8081 og 8181. Til å forenkle, default er å bruke samme port som aplikasjon selv (8080)

Jeg ser ikke så stor forskjell i løsninger i eksponering aspekt. Uansett skal vi begrense eksponerte actuators mellom intern nettverk actuators, og ikke eksponere hele /actuators path.