### PR TITLE
Feature/bg/api 388 dataset change handling

### DIFF
--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/CrawlerJobFactory.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/CrawlerJobFactory.java
@@ -21,7 +21,7 @@ import javax.annotation.PostConstruct;
 
 @Component
 public class CrawlerJobFactory {
-	
+
 	@Autowired
 	private FusekiSettings fusekiSettings;
 
@@ -36,10 +36,10 @@ public class CrawlerJobFactory {
 
 	@Autowired
 	private EmailNotificationService emailNotificationService;
-	
+
 	private AdminDataStore adminDataStore;
 	private DcatDataStore dcatDataStore;
-	
+
 	private FusekiResultHandler fusekiResultHandler;
 	private ElasticSearchResultHandler elasticSearchResultHandler;
 	private CrawlerResultHandler publisherHandler;
@@ -53,7 +53,7 @@ public class CrawlerJobFactory {
 		dcatDataStore = new DcatDataStore(new Fuseki(fusekiSettings.getDcatServiceUri()));
 		fusekiResultHandler = new FusekiResultHandler(dcatDataStore, adminDataStore);
 	}
-	
+
 	public CrawlerJob createCrawlerJob(DcatSource dcatSource) {
 
 		logger.debug("elastic.clusterNodes: " + elasticSettings.getClusterNodes());
@@ -62,6 +62,7 @@ public class CrawlerJobFactory {
 		logger.debug("application.httpUsername: " + applicationSettings.getHttpUsername());
 		logger.debug("application.httpPassword: " + applicationSettings.getHttpPassword());
 		logger.debug("application.notificationMailSenderAddress" + applicationSettings.getNotificationMailSenderAddress());
+		logger.debug("application.harvestRecordRetentionDays: " + applicationSettings.getHarvestRecordRetentionDays());
 
 		publisherHandler = new ElasticSearchResultPubHandler(elasticSettings.getClusterNodes(), elasticSettings.getClusterName());
 		elasticSearchResultHandler = new ElasticSearchResultHandler(
@@ -71,7 +72,8 @@ public class CrawlerJobFactory {
 				applicationSettings.getHttpUsername(),
 				applicationSettings.getHttpPassword(),
 				applicationSettings.getNotificationMailSenderAddress(),
-				emailNotificationService);
+				emailNotificationService,
+                applicationSettings.getHarvestRecordRetentionDays());
 
 		return new CrawlerJob(dcatSource, adminDataStore, subjectCrawler, fusekiResultHandler, elasticSearchResultHandler, publisherHandler);
 	}

--- a/applications/harvester-api/src/main/java/no/dcat/harvester/settings/ApplicationSettings.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/settings/ApplicationSettings.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix="application")
 public class ApplicationSettings {
-	
+
 	private String referenceDataUrl;
 
 	private String httpUsername;
@@ -18,6 +18,7 @@ public class ApplicationSettings {
 
 	private String openDataEnhet;
 
+	private int harvestRecordRetentionDays;
 
 	public String getHttpUsername() {
 		return httpUsername;
@@ -57,5 +58,11 @@ public class ApplicationSettings {
 
 	public void setOpenDataEnhet(String openDataEnhet) {
 		this.openDataEnhet = openDataEnhet;
+	}
+
+	public int getHarvestRecordRetentionDays() { return harvestRecordRetentionDays; }
+
+	public void setHarvestRecordRetentionDays(int harvestRecordRetentionDays) {
+	    this.harvestRecordRetentionDays = harvestRecordRetentionDays;
 	}
 }

--- a/applications/harvester-api/src/main/resources/application.yml
+++ b/applications/harvester-api/src/main/resources/application.yml
@@ -12,6 +12,7 @@ application:
   referenceDataUrl: ${referenceDataUrl:http://reference-data:8080}
   notificationMailSenderAddress: fdksystembjg@gmail.com
   openDataEnhet: https://data.brreg.no/enhetsregisteret/api/enheter/
+  harvestRecordRetentionDays: ${harvestRecordRetentionDays:1000}
 crawler:
   threadPoolSize: 2
 elastic:

--- a/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandlerTest.java
+++ b/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandlerTest.java
@@ -825,4 +825,6 @@ public class ElasticSearchResultHandlerTest {
         resultHandler.isChanged(record, dataset2, gson);
 
     }
+
+
 }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -64,6 +64,7 @@ services:
     - fuseki.dcatServiceUri=http://fuseki:8080/fuseki/dcat
     - fuseki.adminServiceUri=http://fuseki:8080/fuseki/admin
     - application.crawlerThreadPoolSize=2
+    - harvestRecordRetentionDays=30
     volumes:
     - ./logs:/usr/local/tomcat/logs:rw
 


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-388

Funksjonalitet for å slette harvest records eldre enn et visst antall dager.
Antall dager spesifiseres i en property. denne er lagt inn for alle miljøer i Jenkins.
Antall dageer er satt til 30 for alle miljøer.

Har opprettet ny sak for forbedret endringshåndtering: https://jira.brreg.no/browse/API-813

Fant ikke ut hvordan jeg skulle lage en fornuftig test for dette, fordi det må eksistere historikk som er mer enn en dag gammel for å teste dette.

Denne bør ikke produksjonssettes på dagtid, da det er mulig at sletting av harvest records i produksjonsmiljø vil kreve mye ressurser av Elasticsearch - her er det harvest records langt tilbake i tid.
Vi bør overvåke tidsforbruk / belastning når vi deployer til de andre miljøene.